### PR TITLE
Verifiers to require analyzer and code fix implementations

### DIFF
--- a/test/CodeCracker.Test/ArgumentExceptionTests.cs
+++ b/test/CodeCracker.Test/ArgumentExceptionTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -72,6 +73,16 @@ namespace CodeCracker.Test
         }
     }";
             VerifyCSharpFix(test, fixtest, 1);
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/test/CodeCracker.Test/CatchEmptyTests.cs
+++ b/test/CodeCracker.Test/CatchEmptyTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using System;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
 using Xunit;
@@ -80,6 +81,16 @@ namespace CodeCracker.Test
         }
     }";
             VerifyCSharpFix(test, fixtest, 0);
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/test/CodeCracker.Test/EmptyObjectInitializerTests.cs
+++ b/test/CodeCracker.Test/EmptyObjectInitializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -63,6 +64,16 @@ namespace CodeCracker.Test
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new EmptyObjectInitializerCodeFixProvider();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/ForInArrayTests.cs
+++ b/test/CodeCracker.Test/ForInArrayTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -388,6 +389,16 @@ namespace CodeCracker.Test
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ForInArrayAnalyzer();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/ObjectInitializerTests.cs
+++ b/test/CodeCracker.Test/ObjectInitializerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -176,6 +177,16 @@ namespace CodeCracker.Test
         {
             return new ObjectInitializerAnalyzer();
         }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class ObjectInitializerWithAssingmentTests : CodeFixVerifier
@@ -319,6 +330,16 @@ namespace CodeCracker.Test
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new ObjectInitializerAnalyzer();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/RethrowExceptionTests.cs
+++ b/test/CodeCracker.Test/RethrowExceptionTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -115,6 +116,16 @@ namespace CodeCracker.Test
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new RethrowExceptionAnalyzer();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/TernaryOperatorTests.cs
+++ b/test/CodeCracker.Test/TernaryOperatorTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -189,6 +190,16 @@ namespace CodeCracker.Test
         {
             return new TernaryOperatorAnalyzer();
         }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class TernaryOperatorWithReturnTests : CodeFixVerifier
@@ -315,6 +326,16 @@ namespace CodeCracker.Test
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new TernaryOperatorAnalyzer();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/UnnecessaryParenthesisTests.cs
+++ b/test/CodeCracker.Test/UnnecessaryParenthesisTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -75,6 +76,16 @@ namespace CodeCracker.Test
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new UnnecessaryParenthesisCodeFixProvider();
+        }
+
+        protected override CodeFixProvider GetBasicCodeFixProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/CodeCracker.Test/Verifiers/CodeFixVerifier.cs
+++ b/test/CodeCracker.Test/Verifiers/CodeFixVerifier.cs
@@ -20,19 +20,13 @@ namespace TestHelper
         /// Returns the codefix being tested (C#) - to be implemented in non-abstract class
         /// </summary>
         /// <returns>The CodeFixProvider to be used for CSharp code</returns>
-        protected virtual CodeFixProvider GetCSharpCodeFixProvider()
-        {
-            return null;
-        }
+        protected abstract CodeFixProvider GetCSharpCodeFixProvider();
 
         /// <summary>
         /// Returns the codefix being tested (VB) - to be implemented in non-abstract class
         /// </summary>
         /// <returns>The CodeFixProvider to be used for VisualBasic code</returns>
-        protected virtual CodeFixProvider GetBasicCodeFixProvider()
-        {
-            return null;
-        }
+        protected abstract CodeFixProvider GetBasicCodeFixProvider();
 
         /// <summary>
         /// Called to test a C# codefix when applied on the inputted string as a source

--- a/test/CodeCracker.Test/Verifiers/DiagnosticVerifier.cs
+++ b/test/CodeCracker.Test/Verifiers/DiagnosticVerifier.cs
@@ -17,18 +17,12 @@ namespace TestHelper
         /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
         /// </summary>
-        protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return null;
-        }
+        protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
 
         /// <summary>
         /// Get the Visual Basic analyzer being tested (C#) - to be implemented in non-abstract class
         /// </summary>
-        protected virtual DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return null;
-        }
+        protected abstract DiagnosticAnalyzer GetBasicDiagnosticAnalyzer();
         #endregion
 
         #region Verifier wrappers


### PR DESCRIPTION
While I was creating new test classes that implemented the verifiers, they depend on getting the proper implementations of analyzers and code fixes in order to work properly -- and if you forgot to provide those, the errors didn't make it clear that they were missing.
