### PR TITLE
Fixes the expected diagnostic description for the test

### DIFF
--- a/test/CodeCracker.Test/AlwaysUseVarTests.cs
+++ b/test/CodeCracker.Test/AlwaysUseVarTests.cs
@@ -112,7 +112,7 @@ namespace CodeCracker.Test
             var expected = new DiagnosticResult
             {
                 Id = AlwaysUseVarAnalyzer.DiagnosticId,
-                Message = "Use 'var' instead specifying the type name.",
+                Message = "Use 'var' instead of specifying the type name.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
             };


### PR DESCRIPTION
The message had a grammar error that @ElemarJR fixed, but the test wasn't updated accordingly. Remember to run all tests before pushing! :grin: 
