### PR TITLE
Fix ForInArrayAnalyzer where it would break when array was not in scope

### DIFF
--- a/src/CodeCracker/ForInArrayAnalyzer.cs
+++ b/src/CodeCracker/ForInArrayAnalyzer.cs
@@ -52,8 +52,8 @@ namespace CodeCracker
                                         let initSymbol = context.SemanticModel.GetSymbolInfo(init.ArgumentList.Arguments.First().Expression).Symbol
                                         where controlVarId.Equals(initSymbol)
                                         let someArrayInit = context.SemanticModel.GetSymbolInfo(init.Expression).Symbol as ILocalSymbol
-                                        where someArrayInit.Equals(arrayId)
-                                        select someArrayInit).ToList();
+                                        where someArrayInit == null || someArrayInit.Equals(arrayId)
+                                        select arrayId).ToList();
             if (!arrayAccessorSymbols.Any()) return;
 
             var diagnostic = Diagnostic.Create(Rule, forStatement.ForKeyword.GetLocation(), "You can use foreach instead of for.");

--- a/test/CodeCracker.Test/ForInArrayTests.cs
+++ b/test/CodeCracker.Test/ForInArrayTests.cs
@@ -334,6 +334,39 @@ namespace CodeCracker.Test
         }
 
         [Fact]
+        public void ForInArrayAnalyzerWhereArrayIsInitializedOutsideTheScopeCreatesDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                Foo(array);
+            }
+            public int Foo(int[] array)
+            {
+                for (var i = 0; i < array.Length; i++)
+                {
+                    var item = array[i];
+                    // whatever comes after
+                }
+            }
+        }
+    }";
+            var expected = new DiagnosticResult
+            {
+                Id = ForInArrayAnalyzer.DiagnosticId,
+                Message = "You can use foreach instead of for.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 17) }
+            };
+            VerifyCSharpDiagnostic(source, expected);
+        }
+
+        [Fact]
         public void WhenUsingForWithAnArrayThenChangesToForeach()
         {
             const string source = @"


### PR DESCRIPTION
If array in the `for` declaration was declared outside the method scope
the symbol would not be found and an null reference exception would
be thrown. See associated test to an example of the now fixed case.

Bug found from issue #3.
