### PR TITLE
Add help links and descriptions to analyzers

### DIFF
--- a/src/CodeCracker/AlwaysUseVarAnalyzer.cs
+++ b/src/CodeCracker/AlwaysUseVarAnalyzer.cs
@@ -14,7 +14,18 @@ namespace CodeCracker
         internal const string Title = "You should use 'var' whenever possible.";
         internal const string MessageFormat = "Use 'var' instead of specifying the type name.";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "Usage of an implicit type improve readability of the code.\r\n"
+            + "Code depending on types for their readability should be refactored with better variable "
+            + "names or by introducing well-named methods.";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description:Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/ArgumentExceptionAnalyzer.cs
+++ b/src/CodeCracker/ArgumentExceptionAnalyzer.cs
@@ -14,7 +14,18 @@ namespace CodeCracker
         internal const string Title = "Invalid argument name";
         internal const string MessageFormat = "Type argument '{0}' is not in the argument list.";
         internal const string Category = "Naming";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "The string passed as the 'paramName' argument of ArgumentException constructor "
+            + "must be the name of one of the method arguments.\r\n"
+            + "It can be either specified directly or using the nameof() operator (C#6 only)";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description:Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/CatchEmptyAnalyzer.cs
+++ b/src/CodeCracker/CatchEmptyAnalyzer.cs
@@ -13,7 +13,14 @@ namespace CodeCracker
         internal const string Title = "Your catch maybe include some Exception";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/CodeCracker.csproj
+++ b/src/CodeCracker/CodeCracker.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Extensions\AnalyzerExtensions.cs" />
     <Compile Include="EmptyFinalizerAnalyzer.cs" />
     <Compile Include="EmptyFinalizerCodeFixProvider.cs" />
+    <Compile Include="HelpLink.cs" />
     <Compile Include="MakeLocalVariableConstWhenItIsPossibleAnalyzer.cs" />
     <Compile Include="MakeLocalVariableConstWhenItIsPossibleCodeFixProvider.cs" />
     <Compile Include="NameOfAnalyzer.cs" />

--- a/src/CodeCracker/ConvertToSwitchAnalyzer.cs
+++ b/src/CodeCracker/ConvertToSwitchAnalyzer.cs
@@ -15,7 +15,18 @@ namespace CodeCracker
         internal const string Title = "Use 'switch'";
         internal const string MessageFormat = "You could use 'switch' instead of 'if'.";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true);
+        const string Description = "Multiple 'if' and 'else if' on the same variable can be replaced with a 'switch'"
+            + "on the variable\r\n\r\n"
+            + "Note: This diagnostic trigger for 3 or more 'case' statements";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/CopyEventToVariableBeforeFireAnalyzer.cs
+++ b/src/CodeCracker/CopyEventToVariableBeforeFireAnalyzer.cs
@@ -14,8 +14,19 @@ namespace CodeCracker
         internal const string Title = "Copy Event To Variable Before Fire";
         internal const string MessageFormat = "Copy the '{0}' event to a variable before fire it.";
         internal const string Category = "Warning";
-
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        const string Description = "Events should always be checked for null before being invoked.\r\n"
+            + "As in a multi-threading context it is possible for an event to be unsuscribed between "
+            + "the moment where it is checked to be non-null and the moment it is raised the event must "
+            + "be copied to a temporary variable before the check.";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
+++ b/src/CodeCracker/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
@@ -13,8 +13,18 @@ namespace CodeCracker
         internal const string Title = "Disposables Should Call Suppress Finalize";
         internal const string MessageFormat = "'{0}' should call GC.SuppressFinalize inside the Dispose method.";
         internal const string Category = "Warning";
-
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        const string Description = "Classes implementing IDisposable should call the GC.SuppressFinalize method in their "
+            + "finalize method to avoid any finalizer from being called.\r\n"
+            + "This rule should be followed even if the class doesn't have a finalizer as a derived class could have one.";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description:Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/EmptyCatchBlockAnalyzer.cs
+++ b/src/CodeCracker/EmptyCatchBlockAnalyzer.cs
@@ -13,7 +13,17 @@ namespace CodeCracker
         internal const string Title = "Catch block cannot be empty";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        const string Description = "An empty catch block suppress all errors and shouldn't be used.\r\n"
+            +"If the error is expected consider logging it or changing the control flow such that it is explicit.";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/EmptyFinalizerAnalyzer.cs
+++ b/src/CodeCracker/EmptyFinalizerAnalyzer.cs
@@ -14,8 +14,20 @@ namespace CodeCracker
         internal const string Title = "Remove Empty Finalizers";
         internal const string MessageFormat = "Remove Empty Finalizers";
         internal const string Category = "Performance";
+        const string Description = "An empty finalizer will stop your object from being collected immediately by the "
+            + "Garbage Collector when no longer used."
+            + "It will instead be placed in the finalizer queue needlessly using resources.";
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            customTags: WellKnownDiagnosticTags.Unnecessary,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/EmptyObjectInitializerAnalyzer.cs
+++ b/src/CodeCracker/EmptyObjectInitializerAnalyzer.cs
@@ -13,7 +13,19 @@ namespace CodeCracker
         internal const string Title = "Empty Object Initializer";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "An empty object initializer doesn't add any information and only clutter the code.\r\n"
+            + "If there is no member to initialize, prefer using the standard constructor syntax.";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            customTags: WellKnownDiagnosticTags.Unnecessary,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/ExistenceOperatorAnalyzer.cs
+++ b/src/CodeCracker/ExistenceOperatorAnalyzer.cs
@@ -13,7 +13,16 @@ namespace CodeCracker
         internal const string Title = "Use the existence operator";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true);
+        const string Description = "The null-propagating operator allow for terse code to handle potentially null variables.";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/ForInArrayAnalyzer.cs
+++ b/src/CodeCracker/ForInArrayAnalyzer.cs
@@ -14,7 +14,15 @@ namespace CodeCracker
         internal const string Title = "Use foreach";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/HelpLink.cs
+++ b/src/CodeCracker/HelpLink.cs
@@ -1,0 +1,10 @@
+﻿namespace CodeCracker
+{
+    static class HelpLink
+    {
+        public static string ForDiagnostic(string diagnosticId)
+        {
+            return "https://code-cracker.github.io/diagnostics/\{diagnosticId}.html";
+        }
+    }
+}

--- a/src/CodeCracker/IfReturnTrueAnalyzer.cs
+++ b/src/CodeCracker/IfReturnTrueAnalyzer.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace CodeCracker
 {
@@ -14,7 +13,18 @@ namespace CodeCracker
         internal const string Title = "Return Condition directly";
         internal const string Message = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, Message, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "Using an if/else to return true/false depending on the condition isn't useful.\r\n"
+            + "As the condition is already a boolean it can be returned directly";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            Message,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/MakeLocalVariableConstWhenItIsPossibleAnalyzer.cs
+++ b/src/CodeCracker/MakeLocalVariableConstWhenItIsPossibleAnalyzer.cs
@@ -15,7 +15,16 @@ namespace CodeCracker
         internal const string Title = "Make Local Variable Constant.";
         internal const string MessageFormat = "This variables can be made const.";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true);
+        const string Description = "This variable is assigned a constant value and never changed it can be made 'const'";
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/NameOfAnalyzer.cs
+++ b/src/CodeCracker/NameOfAnalyzer.cs
@@ -14,7 +14,18 @@ namespace CodeCracker
         internal const string Title = "You should use nameof instead of the parameter string";
         internal const string MessageFormat = "Use 'nameof({0})' instead of specifying the parameter name.";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "In C#6 the nameof() operator should be used to specify the name of a parameter instead of "
+            + "a string literal as it produce code that is easier to refactor.";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/ObjectInitializerAnalyzer.cs
+++ b/src/CodeCracker/ObjectInitializerAnalyzer.cs
@@ -17,8 +17,18 @@ namespace CodeCracker
         internal const string Category = "Syntax";
         public const string DiagnosticIdAssignment = "CC0009";
         internal const string TitleAssignment = "Use object initializer";
+        const string Description = "When possible an object initializer should be used to initialize the properties of an "
+            + "object instead of multiple assignments.";
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticIdLocalDeclaration, TitleLocalDeclaration, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticIdLocalDeclaration,
+            TitleLocalDeclaration,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticIdLocalDeclaration));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/RegexAnalyzer.cs
+++ b/src/CodeCracker/RegexAnalyzer.cs
@@ -14,7 +14,18 @@ namespace CodeCracker
         internal const string Title = "Your Regex expression is wrong";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true);
+        const string Description = "This diagnostic compile the Regex expression and trigger if the compilation fail "
+            + "by throwing an exception.";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/RemoveWhereWhenItIsPossibleAnalyzer.cs
+++ b/src/CodeCracker/RemoveWhereWhenItIsPossibleAnalyzer.cs
@@ -11,9 +11,12 @@ namespace CodeCracker
     public class RemoveWhereWhenItIsPossibleAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "CC0011";
-        internal const string Title = "You should remove the 'Where' invokation when it is possible.";
+        internal const string Title = "You should remove the 'Where' invocation when it is possible.";
         internal const string MessageFormat = "You can remove 'Where' moving the predicate to '{0}'.";
         internal const string Category = "Syntax";
+        const string Description = "When a linq operator support a predicate parameter it should be used instead of "
+            + "using 'Where' followed by the operator";
+
         static readonly string[] supportedMethods = new[] {
             "First",
             "FirstOrDefault",
@@ -24,7 +27,15 @@ namespace CodeCracker
             "SingleOrDefault",
             "Count"
         };
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -45,7 +56,7 @@ namespace CodeCracker
             if (!supportedMethods.Contains(candidate)) return;
 
             if (nextMethodInvoke.ArgumentList.Arguments.Any()) return;
-
+            
             var diagnostic = Diagnostic.Create(Rule, GetNameExpressionOfTheInvokedMethod(whereInvoke).GetLocation(), candidate);
             context.ReportDiagnostic(diagnostic);
         }

--- a/src/CodeCracker/RethrowExceptionAnalyzer.cs
+++ b/src/CodeCracker/RethrowExceptionAnalyzer.cs
@@ -14,7 +14,19 @@ namespace CodeCracker
         internal const string Title = "Your throw does nothing";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "Throwing the same exception as passed to the 'catch' block lose the original "
+            + "stack trace and will make debugging this exception a lot more difficult.\r\n"
+            + "The correct way to rethrow an exception without changing it is by using 'throw' without any parameter.";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/SealedAttributeAnalyzer.cs
+++ b/src/CodeCracker/SealedAttributeAnalyzer.cs
@@ -12,8 +12,18 @@ namespace CodeCracker
         internal const string Title = "Unsealed Attribute";
         internal const string MessageFormat = "Mark '{0}' as sealed.";
         internal const string Category = "Performance";
+        const string Description = "Framework methods that retrieve attributes by default search the whole "
+            + "inheritence hierarchy of the attribute class. "
+            + "Marking the type as sealed eliminate this search and can improve performance";
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/StaticConstructorExceptionAnalyzer.cs
+++ b/src/CodeCracker/StaticConstructorExceptionAnalyzer.cs
@@ -14,8 +14,20 @@ namespace CodeCracker
         internal const string Title = "Don't throw exception inside static constructors.";
         internal const string MessageFormat = "Don't throw exception inside static constructors.";
         internal const string Category = "Usage";
+        const string Description = "Static constructor are called before the first time a class is used but the "
+            + "caller doesn't control when exactly.\r\n"
+            + "Exception thrown in this context force callers to use 'try' block around any useage of the class "
+            + "and should be avoided.";
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/TernaryOperatorAnalyzer.cs
+++ b/src/CodeCracker/TernaryOperatorAnalyzer.cs
@@ -17,8 +17,24 @@ namespace CodeCracker
         public const string DiagnosticIdForIfWithAssignment = "CC0014";
         internal const string TitleForIfWithAssignment = "User ternary operator";
         internal const string MessageFormatForIfWithAssignment = "{0}";
-        internal static DiagnosticDescriptor RuleForIfWithReturn = new DiagnosticDescriptor(DiagnosticIdForIfWithReturn, TitleForIfWithReturn, MessageFormatForIfWithReturn, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
-        internal static DiagnosticDescriptor RuleForIfWithAssignment = new DiagnosticDescriptor(DiagnosticIdForIfWithAssignment, TitleForIfWithAssignment, MessageFormatForIfWithAssignment, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        internal static DiagnosticDescriptor RuleForIfWithReturn = new DiagnosticDescriptor(
+            DiagnosticIdForIfWithReturn,
+            TitleForIfWithReturn,
+            MessageFormatForIfWithReturn,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticIdForIfWithReturn));
+
+        internal static DiagnosticDescriptor RuleForIfWithAssignment = new DiagnosticDescriptor(
+            DiagnosticIdForIfWithAssignment,
+            TitleForIfWithAssignment,
+            MessageFormatForIfWithAssignment,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticIdForIfWithAssignment));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(RuleForIfWithReturn, RuleForIfWithAssignment); } }
 

--- a/src/CodeCracker/UnnecessaryParenthesisAnalyzer.cs
+++ b/src/CodeCracker/UnnecessaryParenthesisAnalyzer.cs
@@ -13,7 +13,19 @@ namespace CodeCracker
         internal const string Title = "Unnecessary Parenthesis";
         internal const string MessageFormat = "{0}";
         internal const string Category = "Syntax";
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        const string Description = "There is no need to specify that the no-parameter constructor is used with "
+            + " an initializer as it is implicit";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            customTags: WellKnownDiagnosticTags.Unnecessary,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/CodeCracker/UseInvokeMethodToFireEventAnalyzer.cs
+++ b/src/CodeCracker/UseInvokeMethodToFireEventAnalyzer.cs
@@ -14,8 +14,18 @@ namespace CodeCracker
         internal const string Title = "Use Invoke Method To Fire Event Analyzer";
         internal const string MessageFormat = "Use ?.Invoke operator and method to fire '{0}' event.";
         internal const string Category = "Warning";
+        const string Description = "In C#6 an event can be invoked using the null-propagating operator (?.) and it's"
+            + "invoke method to avoid throwing a NullReference exception when there is no event handler attached.";
 
-        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true);
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description: Description,
+            helpLink: HelpLink.ForDiagnostic(DiagnosticId));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 


### PR DESCRIPTION
- I'm not an english native speaker so I hope that I didn't type anything that doesn't make sense.
- I placed the code to generate the URL for help links in a separate file so it's easy to change.
- Some analyzers like `TernaryOperatorAnalyzer` have 2 diagnostics with different IDs, maybe they should point to the same help page
- Obviously none of the page exists right now. A potential solution could be to return null inside the help link generating class for now and switch to the final URL once enough documentation is written.

> For some of them I didn't had any good description that
> wasn't a repetition of the text so I avoided to add it
> but still added the help link to all of them.
> 
> While reviewing all of them I also added the tag to get
> greyed-text on analyzer indicating unnecesary constructs:
> 
> ```
> customTags: WellKnownDiagnosticTags.Unnecessary
> ```
> 
> Follow the discussion in #78
