### PR TITLE
Call extension method as an extension #27 (Second Time)

### DIFF
--- a/src/CodeCracker/CodeCracker.csproj
+++ b/src/CodeCracker/CodeCracker.csproj
@@ -43,6 +43,8 @@
     <Compile Include="Style\ConvertToSwitchCodeFixProvider.cs" />
     <Compile Include="Design\CopyEventToVariableBeforeFireAnalyzer.cs" />
     <Compile Include="Design\CopyEventToVariableBeforeFireCodeFixProvider.cs" />
+    <Compile Include="Usage\CallExtensionMethodAsExtensionAnalyzer.cs" />
+    <Compile Include="Usage\CallExtensionMethodAsExtensionCodeFixProvider.cs" />
     <Compile Include="Usage\DisposablesShouldCallSuppressFinalizeAnalyzer.cs" />
     <Compile Include="Usage\DisposablesShouldCallSuppressFinalizeCodeFixProvider.cs" />
     <Compile Include="Style\ExistenceOperatorAnalyzer.cs" />

--- a/src/CodeCracker/Usage/CallExtensionMethodAsExtensionAnalyzer.cs
+++ b/src/CodeCracker/Usage/CallExtensionMethodAsExtensionAnalyzer.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+namespace CodeCracker.Usage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CallExtensionMethodAsExtensionAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CC0026";
+        internal const string Title = "Call Extension Method As Extension";
+        internal const string MessageFormat = "Do not call '{0}' method of class '{1}' as a static method";
+        internal const string Category = SupportedCategories.Usage;
+
+        internal static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(
+                DiagnosticId,
+                Title,
+                MessageFormat,
+                Category,
+                DiagnosticSeverity.Info,
+                isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get { return ImmutableArray.Create(Rule); }
+        }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.InvocationExpression);
+        }
+
+        private void Analyzer(SyntaxNodeAnalysisContext context)
+        {
+            var methodInvokeSyntax = context.Node as InvocationExpressionSyntax;
+
+            var childNodes = methodInvokeSyntax.ChildNodes();
+
+            var methodCaller = childNodes
+                                .OfType<MemberAccessExpressionSyntax>()
+                                .FirstOrDefault();
+
+            if (methodCaller == null) return;
+
+            var argumentsCount = CountArguments(childNodes);
+
+            var classSymbol = GetCallerClassSymbol(context.SemanticModel, methodCaller.Expression);
+            if (classSymbol == null || !classSymbol.MightContainExtensionMethods) return;
+
+            var methodSymbol = GetCallerMethodSymbol(context.SemanticModel, methodCaller.Name, argumentsCount);
+            if (methodSymbol == null || !methodSymbol.IsExtensionMethod) return;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rule,
+                    methodCaller.GetLocation(),
+                    methodSymbol.Name,
+                    classSymbol.Name
+                ));
+        }
+
+        private static int CountArguments(IEnumerable<SyntaxNode> childNodes)
+        {
+            return childNodes
+                    .OfType<ArgumentListSyntax>()
+                    .Select(s => s.Arguments.Count)
+                    .FirstOrDefault();
+        }
+
+        private IMethodSymbol GetCallerMethodSymbol(SemanticModel semanticModel, SimpleNameSyntax name, int argumentsCount)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(name);
+
+            return symbolInfo.Symbol as IMethodSymbol ??
+                    symbolInfo
+                        .CandidateSymbols
+                        .OfType<IMethodSymbol>()
+                        .FirstOrDefault(s => s.Parameters.Count() == argumentsCount + 1);
+        }
+
+        private INamedTypeSymbol GetCallerClassSymbol(SemanticModel semanticModel, ExpressionSyntax expression)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(expression);
+            return symbolInfo.Symbol as INamedTypeSymbol;
+        }
+    }
+}

--- a/src/CodeCracker/Usage/CallExtensionMethodAsExtensionCodeFixProvider.cs
+++ b/src/CodeCracker/Usage/CallExtensionMethodAsExtensionCodeFixProvider.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+namespace CodeCracker.Usage
+{
+    [ExportCodeFixProvider("CodeCrackerCallExtensionMethodAsExtensionCodeFixProvider", LanguageNames.CSharp)]
+    public class CallExtensionMethodAsExtensionCodeFixProvider : CodeFixProvider
+    {
+        public override async Task ComputeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var staticInvocationExpression = root
+                .FindToken(diagnosticSpan.Start)
+                .Parent.AncestorsAndSelf()
+                .OfType<InvocationExpressionSyntax>()
+                .First();
+
+            context.RegisterFix(
+                CodeAction.Create(
+                    "Use extension method as an extension",
+                    cancellationToken => CallAsExtensionAsync(context.Document, staticInvocationExpression, cancellationToken)),
+                    diagnostic);
+        }
+
+        public override ImmutableArray<string> GetFixableDiagnosticIds()
+        {
+            return ImmutableArray.Create(CallExtensionMethodAsExtensionAnalyzer.DiagnosticId);
+        }
+
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        private async Task<Document> CallAsExtensionAsync(Document document, InvocationExpressionSyntax staticInvocationExpression, CancellationToken cancellationToken)
+        {
+            var childNodes = staticInvocationExpression.ChildNodes();
+
+            var parametersExpression =
+                childNodes
+                    .OfType<ArgumentListSyntax>()
+                    .SelectMany(s => s.Arguments)
+                    .Select(s => s.Expression);
+
+            var firstArgument = parametersExpression.FirstOrDefault();
+            var callerMethod = childNodes.OfType<MemberAccessExpressionSyntax>().FirstOrDefault();
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken) as CompilationUnitSyntax;
+
+            root = ReplaceStaticCallWithExtionMethodCall(
+                        root,
+                        staticInvocationExpression,
+                        firstArgument,
+                        callerMethod.Name,
+                        CreateArgumentListSyntaxFrom(parametersExpression.Skip(1))
+                   ).WithAdditionalAnnotations(Formatter.Annotation);
+
+            SemanticModel semanticModel;
+            if (document.TryGetSemanticModel(out semanticModel))
+                root = ImportNeededNamespace(root, semanticModel, callerMethod).WithAdditionalAnnotations(Formatter.Annotation);
+
+            var newDocument = document.WithSyntaxRoot(root);
+
+            return newDocument;
+        }
+
+        public ArgumentListSyntax CreateArgumentListSyntaxFrom(IEnumerable<ExpressionSyntax> expressions)
+        {
+            return SyntaxFactory
+                    .ArgumentList()
+                    .AddArguments(expressions.Select(s => SyntaxFactory.Argument(s)).ToArray());
+        }
+
+        private CompilationUnitSyntax ReplaceStaticCallWithExtionMethodCall(CompilationUnitSyntax root, InvocationExpressionSyntax staticInvocationExpression, ExpressionSyntax sourceExpression, SimpleNameSyntax methodName, ArgumentListSyntax argumentList)
+        {
+            var extensionInvocationExpression =
+                SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        sourceExpression,
+                        methodName),
+                        argumentList
+                    )
+                    .WithLeadingTrivia(staticInvocationExpression.GetLeadingTrivia());
+
+            return root.ReplaceNode(staticInvocationExpression, extensionInvocationExpression);
+        }
+
+        private CompilationUnitSyntax ImportNeededNamespace(CompilationUnitSyntax root, SemanticModel semanticModel, MemberAccessExpressionSyntax callerMethod)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(callerMethod.Name);
+            var methodSymbol = symbolInfo.Symbol as IMethodSymbol;
+
+            if (methodSymbol == null) return root;
+
+            var namespaceDisplayString = methodSymbol.ContainingNamespace.ToDisplayString();
+
+            var hasNamespaceImported = root
+                .DescendantNodes()
+                .OfType<UsingDirectiveSyntax>()
+                .Select(s => s.DescendantNodes().OfType<IdentifierNameSyntax>())
+                .Select(s => TransformIdentifierNameSyntaxIntoNamespace(s))
+                .Any(p => p == namespaceDisplayString);
+
+            if (!hasNamespaceImported)
+            {
+                var namespaceQualifiedName = GenerateNamespaceQualifiedName(namespaceDisplayString.Split('.'));
+                root = root.AddUsings(SyntaxFactory.UsingDirective(namespaceQualifiedName));
+            }
+            return root;
+        }
+
+        private string TransformIdentifierNameSyntaxIntoNamespace(IEnumerable<IdentifierNameSyntax> usingIdentifierNames)
+        {
+            return string.Join(".", usingIdentifierNames.Select(s => s.Identifier.ValueText).ToArray());
+        }
+
+        private NameSyntax GenerateNamespaceQualifiedName(IEnumerable<string> names)
+        {
+            var total = names.Count();
+
+            if (total == 1)
+                return SyntaxFactory.IdentifierName(names.First());
+
+            return SyntaxFactory.QualifiedName(
+                GenerateNamespaceQualifiedName(names.Take(total - 1)),
+                GenerateNamespaceQualifiedName(names.Skip(total - 1)) as IdentifierNameSyntax
+            );
+        }
+    }
+}

--- a/test/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CodeCracker.Test/CodeCracker.Test.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Usage\ArgumentExceptionTests.cs" />
     <Compile Include="Style\ConvertToSwitchTests.cs" />
     <Compile Include="Design\CopyEventToVariableBeforeFireTests.cs" />
+    <Compile Include="Usage\CallExtensionMethodAsExtensionTests.cs" />
     <Compile Include="Usage\DisposablesShouldCallSuppressFinalizeTests.cs" />
     <Compile Include="Performance\EmptyFinalizerTests.cs" />
     <Compile Include="Style\ExistenceOperatorTests.cs" />

--- a/test/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
+++ b/test/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
@@ -1,0 +1,196 @@
+﻿using CodeCracker.Usage;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using TestHelper;
+using Xunit;
+namespace CodeCracker.Test.Usage
+{
+    public class CallExtensionMethodAsExtensionTests :
+        CodeFixTest<CallExtensionMethodAsExtensionAnalyzer, CallExtensionMethodAsExtensionCodeFixProvider>
+    {
+        [Fact]
+        public async Task WhenCallExtensionMethodAsExtensionHasNoDiagnostics()
+        {
+            var source = @"
+                    using System.Linq;
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                source.Any(x => x > 1);
+                            }
+                        }
+                    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodAsStaticMenthodTriggerAFix()
+        {
+            var source = @"
+                    using System.Linq;
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                Enumerable.Any(source, x => x > 1);
+                            }
+                        }
+                    }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = CallExtensionMethodAsExtensionAnalyzer.DiagnosticId,
+                Message = "Do not call 'Any' method of class 'Enumerable' as a static method",
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 33) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodWithFullNamespaceAsStaticMenthodTriggerAFix()
+        {
+            var source = @"
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                System.Linq.Enumerable.Any(source);
+                            }
+                        }
+                    }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = CallExtensionMethodAsExtensionAnalyzer.DiagnosticId,
+                Message = "Do not call 'Any' method of class 'Enumerable' as a static method",
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 33) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodAsStaticMenthodShouldFix()
+        {
+            var source = @"
+                    using System.Linq;
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                Enumerable.Any(source, x => x > 1);
+                            }
+                        }
+                    }";
+
+            var expected = @"
+                    using System.Linq;
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                source.Any(x => x > 1);
+                            }
+                        }
+                    }";
+
+            await VerifyCSharpFixAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodWithFullNamespaceAndNotImportedShouldImport()
+        {
+            var source = @"
+                    using System;
+                    using System.Collections;
+                    using System.Collections.Generic;
+
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                System.Linq.Enumerable.Any(source);
+                            }
+                        }
+                    }";
+
+            var expected = @"
+                    using System;
+                    using System.Collections;
+                    using System.Collections.Generic;
+                    using System.Linq;
+
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                source.Any();
+                            }
+                        }
+                    }";
+
+            await VerifyCSharpFixAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodWithChainCallsShouldNotBreakTheChain()
+        {
+            var source = @"
+                    using System.Linq;
+
+                    namespace ConsoleApplication1
+                    {
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                Enumerable.Select(source, (p) => p.ToString()).FirstOrDefault();
+                            }
+                        }
+                    }";
+
+            var expected = @"
+                    using System.Linq;
+
+                    namespace ConsoleApplication1
+                    { 
+                        public class Foo
+                        {
+                            public void Bar()
+                            {
+                                var source = new int[] { 1, 2, 3 };
+                                source.Select((p) => p.ToString()).FirstOrDefault();
+                            }
+                        }
+                    }";
+
+            await VerifyCSharpFixAsync(source, expected);
+        }
+    }
+}


### PR DESCRIPTION
I named the analyser and the fix provider and the test with suffix CallExtensionMethodAsExtension.

In the tests I've tried to cover the following scenarios:
- An method extension. (No warn case)
- An static call, in order to trigger a fix
- A static call with no parameter
- A static call with a parameter
- A static call without parameter and a full namespace declared.
  Because this is my first contribution in an open source project, please, let me know what I need to do if any improvement on that code is necessary

Thanks

PS: It is regarding https://github.com/code-cracker/code-cracker/pull/103 PR.  I did something really wrong in my merge, thus I'm sending a new/fresh pull request
