### PR TITLE
Fix for error in Commit f33e0b9

### DIFF
--- a/src/CodeCracker.Vsix/CodeCracker.Vsix.csproj
+++ b/src/CodeCracker.Vsix/CodeCracker.Vsix.csproj
@@ -47,6 +47,7 @@
     <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -70,6 +71,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="RoslynExts.CS">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.CS.dll</HintPath>
+    </Reference>
+    <Reference Include="RoslynExts.VB">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.VB.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/CodeCracker.Vsix/packages.config
+++ b/src/CodeCracker.Vsix/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RoslynExts" version="1.0.7" targetFramework="net45" />
+</packages>

--- a/src/CodeCracker/CodeCracker.csproj
+++ b/src/CodeCracker/CodeCracker.csproj
@@ -116,6 +116,12 @@
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
+    <Reference Include="RoslynExts.CS">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.CS.dll</HintPath>
+    </Reference>
+    <Reference Include="RoslynExts.VB">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.VB.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>

--- a/src/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CodeCracker/Design/NameOfAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using System.Linq;
+using RoslynExts.CS;
 
 namespace CodeCracker.Design
 {

--- a/src/CodeCracker/Design/UseInvokeMethodToFireEventAnalyzer.cs
+++ b/src/CodeCracker/Design/UseInvokeMethodToFireEventAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Immutable;
+using RoslynExts.CS;
 
 namespace CodeCracker.Design
 {

--- a/src/CodeCracker/Extensions/AnalyzerExtensions.cs
+++ b/src/CodeCracker/Extensions/AnalyzerExtensions.cs
@@ -1,68 +1,68 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using System;
-using System.Linq;
+﻿//using Microsoft.CodeAnalysis;
+//using Microsoft.CodeAnalysis.CSharp;
+//using Microsoft.CodeAnalysis.CSharp.Syntax;
+//using Microsoft.CodeAnalysis.Diagnostics;
+//using System;
+//using System.Linq;
 
-namespace CodeCracker
-{
-    public static class AnalyzerExtensions
-    {
-        public static void RegisterSyntaxNodeAction<TLanguageKindEnum>(this AnalysisContext context, LanguageVersion languageVersion, Action<SyntaxNodeAnalysisContext> action, params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
-        {
-            context.RegisterCompilationStartAction(LanguageVersion.CSharp6, compilationContext => compilationContext.RegisterSyntaxNodeAction(action, syntaxKinds));
-        }
+//namespace CodeCracker
+//{
+//    public static class AnalyzerExtensions
+//    {
+//        public static void RegisterSyntaxNodeAction<TLanguageKindEnum>(this AnalysisContext context, LanguageVersion languageVersion, Action<SyntaxNodeAnalysisContext> action, params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
+//        {
+//            context.RegisterCompilationStartAction(LanguageVersion.CSharp6, compilationContext => compilationContext.RegisterSyntaxNodeAction(action, syntaxKinds));
+//        }
 
-        public static void RegisterCompilationStartAction(this AnalysisContext context, LanguageVersion languageVersion, Action<CompilationStartAnalysisContext> registrationAction)
-        {
-            context.RegisterCompilationStartAction(compilationContext => compilationContext.RunIfCSharp6OrGreater(() => registrationAction(compilationContext)));
-        }
+//        public static void RegisterCompilationStartAction(this AnalysisContext context, LanguageVersion languageVersion, Action<CompilationStartAnalysisContext> registrationAction)
+//        {
+//            context.RegisterCompilationStartAction(compilationContext => compilationContext.RunIfCSharp6OrGreater(() => registrationAction(compilationContext)));
+//        }
 
-        private static void RunIfCSharp6OrGreater(this CompilationStartAnalysisContext context, Action action)
-        {
-            context.Compilation.RunIfCSharp6OrGreater(action);
-        }
+//        private static void RunIfCSharp6OrGreater(this CompilationStartAnalysisContext context, Action action)
+//        {
+//            context.Compilation.RunIfCSharp6OrGreater(action);
+//        }
 
-        private static void RunIfCSharp6OrGreater(this Compilation compilation, Action action)
-        {
-            var cSharpCompilation = compilation as CSharpCompilation;
-            if (cSharpCompilation == null) return;
-            cSharpCompilation.LanguageVersion.RunIfCSharp6OrGreater(action);
-        }
+//        private static void RunIfCSharp6OrGreater(this Compilation compilation, Action action)
+//        {
+//            var cSharpCompilation = compilation as CSharpCompilation;
+//            if (cSharpCompilation == null) return;
+//            cSharpCompilation.LanguageVersion.RunIfCSharp6OrGreater(action);
+//        }
 
-        private static void RunIfCSharp6OrGreater(this LanguageVersion languageVersion, Action action)
-        {
-            if (languageVersion >= LanguageVersion.CSharp6) action();
-        }
+//        private static void RunIfCSharp6OrGreater(this LanguageVersion languageVersion, Action action)
+//        {
+//            if (languageVersion >= LanguageVersion.CSharp6) action();
+//        }
 
-        public static ConditionalAccessExpressionSyntax ToConditionalAccessExpression(this MemberAccessExpressionSyntax memberAccess)
-        {
-            return SyntaxFactory.ConditionalAccessExpression(memberAccess.Expression, SyntaxFactory.MemberBindingExpression(memberAccess.Name));
-        }
+//        public static ConditionalAccessExpressionSyntax ToConditionalAccessExpression(this MemberAccessExpressionSyntax memberAccess)
+//        {
+//            return SyntaxFactory.ConditionalAccessExpression(memberAccess.Expression, SyntaxFactory.MemberBindingExpression(memberAccess.Name));
+//        }
 
-        public static StatementSyntax GetSingleStatementFromPossibleBlock(this StatementSyntax statement)
-        {
-            var block = statement as BlockSyntax;
-            if (block != null)
-            {
-                if (block.Statements.Count != 1) return null;
-                return block.Statements.Single();
-            }
-            else
-            {
-                return statement;
-            }
-        }
+//        public static StatementSyntax GetSingleStatementFromPossibleBlock(this StatementSyntax statement)
+//        {
+//            var block = statement as BlockSyntax;
+//            if (block != null)
+//            {
+//                if (block.Statements.Count != 1) return null;
+//                return block.Statements.Single();
+//            }
+//            else
+//            {
+//                return statement;
+//            }
+//        }
 
-        public static SyntaxNode WithSameTriviaAs(this SyntaxNode target, SyntaxNode source)
-        {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-            if (source == null) throw new ArgumentNullException(nameof(target));
+//        public static SyntaxNode WithSameTriviaAs(this SyntaxNode target, SyntaxNode source)
+//        {
+//            if (target == null) throw new ArgumentNullException(nameof(target));
+//            if (source == null) throw new ArgumentNullException(nameof(source));
 
-            return target
-                .WithLeadingTrivia(source.GetLeadingTrivia())
-                .WithTrailingTrivia(source.GetTrailingTrivia());
-        }
-    }
-}
+//            return target
+//                .WithLeadingTrivia(source.GetLeadingTrivia())
+//                .WithTrailingTrivia(source.GetTrailingTrivia());
+//        }
+//    }
+//}

--- a/src/CodeCracker/StringTypeCodeRefactoringProvider.cs
+++ b/src/CodeCracker/StringTypeCodeRefactoringProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using RoslynExts.CS;
 
 namespace CodeCracker
 {

--- a/src/CodeCracker/Style/ConvertToExpressionBodiedMemberAnalyzer.cs
+++ b/src/CodeCracker/Style/ConvertToExpressionBodiedMemberAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Immutable;
+using RoslynExts.CS;
 
 namespace CodeCracker.Style.Style
 {

--- a/src/CodeCracker/Style/ExistenceOperatorAnalyzer.cs
+++ b/src/CodeCracker/Style/ExistenceOperatorAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using RoslynExts.CS;
 
 namespace CodeCracker.Style
 {

--- a/src/CodeCracker/Style/ExistenceOperatorCodeFixProvider.cs
+++ b/src/CodeCracker/Style/ExistenceOperatorCodeFixProvider.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using RoslynExts.CS;
 
 namespace CodeCracker.Style
 {

--- a/src/CodeCracker/Usage/IfReturnTrueAnalyzer.cs
+++ b/src/CodeCracker/Usage/IfReturnTrueAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using RoslynExts.CS;
 
 namespace CodeCracker.Usage
 {

--- a/src/CodeCracker/Usage/IfReturnTrueCodeFixProvider.cs
+++ b/src/CodeCracker/Usage/IfReturnTrueCodeFixProvider.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using RoslynExts.CS;
 
 namespace CodeCracker.Usage
 {

--- a/src/CodeCracker/packages.config
+++ b/src/CodeCracker/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
+  <package id="RoslynExts" version="1.0.7" targetFramework="portable-net45+win" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />
 </packages>

--- a/test/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CodeCracker.Test/CodeCracker.Test.csproj
@@ -68,6 +68,12 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="RoslynExts.CS">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.CS.dll</HintPath>
+    </Reference>
+    <Reference Include="RoslynExts.VB">
+      <HintPath>..\..\packages\RoslynExts.1.0.7\lib\portable-net45+win8\RoslynExts.VB.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/test/CodeCracker.Test/packages.config
+++ b/test/CodeCracker.Test/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
+  <package id="RoslynExts" version="1.0.7" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
   <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="net45" />


### PR DESCRIPTION
Fixing error in AnalyzerExtension wrong nameof in this commit: https://github.com/code-cracker/code-cracker/commit/f33e0b9e58750e1fbbc0570329eed2b1f8d70cfd

Modified to use RoslynExts (v1.7.0.0)
