### PR TITLE
Convert getter-only properties to expression-bodied members

### DIFF
--- a/src/CodeCracker/Style/ConvertToExpressionBodiedMemberAnalyzer.cs
+++ b/src/CodeCracker/Style/ConvertToExpressionBodiedMemberAnalyzer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Immutable;
 
-namespace CodeCracker.Style.Style
+namespace CodeCracker.Style
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ConvertToExpressionBodiedMemberAnalyzer

--- a/src/CodeCracker/Style/ConvertToExpressionBodiedMemberCodeFixProvider.cs
+++ b/src/CodeCracker/Style/ConvertToExpressionBodiedMemberCodeFixProvider.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
 
-namespace CodeCracker.Style.Style
+namespace CodeCracker.Style
 {
     [ExportCodeFixProvider("CodeCrackerConvertToExpressionBodiedMemberCodeFixProvider", LanguageNames.CSharp), Shared]
     public class ConvertToExpressionBodiedMemberCodeFixProvider : CodeFixProvider

--- a/test/CodeCracker.Test/Style/ConvertToExpressionBodiedMemberTests.cs
+++ b/test/CodeCracker.Test/Style/ConvertToExpressionBodiedMemberTests.cs
@@ -1,4 +1,4 @@
-﻿using CodeCracker.Style.Style;
+﻿using CodeCracker.Style;
 using Microsoft.CodeAnalysis;
 using System.Threading.Tasks;
 using TestHelper;


### PR DESCRIPTION
Getter-only properties with a single return statement can be converted to expression-bodied members. This is an improvement to CC0038 (related to #101).

This

```
public double Area
{
    get { return Width * Height; }
}
```

becomes 

```
public double Area => Width * Height;
```

Also, the codefix was in the namespace CodeCracker.Style.Style (notice the extra .Style).
