### PR TITLE
Wrap generated code in a block if necessary (closes #160)

### DIFF
--- a/src/CSharp/CodeCracker/Design/CopyEventToVariableBeforeFireCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/CopyEventToVariableBeforeFireCodeFixProvider.cs
@@ -67,7 +67,15 @@ namespace CodeCracker.Design
 
             var root = await document.GetSyntaxRootAsync(ct);
 
-            var newRoot = root.ReplaceNode(invocation.Parent, invocation.Parent.WithAdditionalAnnotations(new SyntaxAnnotation(SyntaxAnnotatinKind)));
+            var oldNode = invocation.Parent;
+            var newNode = invocation.Parent.WithAdditionalAnnotations(new SyntaxAnnotation(SyntaxAnnotatinKind));
+
+            if (oldNode.Parent.IsEmbeddedStatementOwner())
+            {
+                newNode = SyntaxFactory.Block((StatementSyntax)newNode);
+            }
+
+            var newRoot = root.ReplaceNode(oldNode, newNode);
             newRoot = newRoot.InsertNodesAfter(GetMark(newRoot), new[] { variable as SyntaxNode, newInvocation as SyntaxNode });
             newRoot = newRoot.RemoveNode(GetMark(newRoot), SyntaxRemoveOptions.KeepNoTrivia);
 

--- a/src/CSharp/CodeCracker/Extensions/AnalyzerExtensions.cs
+++ b/src/CSharp/CodeCracker/Extensions/AnalyzerExtensions.cs
@@ -64,5 +64,18 @@ namespace CodeCracker
                 .WithLeadingTrivia(source.GetLeadingTrivia())
                 .WithTrailingTrivia(source.GetTrailingTrivia());
         }
+
+        public static bool IsEmbeddedStatementOwner(this SyntaxNode node)
+        {
+            return node is IfStatementSyntax ||
+                   node is ElseClauseSyntax ||
+                   node is ForStatementSyntax ||
+                   node is ForEachStatementSyntax ||
+                   node is WhileStatementSyntax ||
+                   node is UsingStatementSyntax ||
+                   node is DoStatementSyntax ||
+                   node is LockStatementSyntax ||
+                   node is FixedStatementSyntax;
+        }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Design/CopyEventToVariableBeforeFireTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/CopyEventToVariableBeforeFireTests.cs
@@ -207,5 +207,38 @@ namespace CodeCracker.Test.Design
 
             await VerifyCSharpFixAsync(source, fixtest, 0);
         }
+
+        [Fact]
+        public async void FixWhenInvocationIsInsideABlockWithoutBraces()
+        {
+            const string source = @"
+                public class MyClass
+                {
+                    public event System.EventHandler MyEvent;
+
+                    public void Execute()
+                    {
+                        if (raiseEvents) MyEvent(this, System.EventArgs.Empty);
+                    }
+                }";
+
+            const string fixtest = @"
+                public class MyClass 
+                {
+                    public event System.EventHandler MyEvent;
+
+                    public void Execute()
+                    {
+                        if (raiseEvents)
+                        {
+                            var handler = MyEvent;
+                            if (handler != null)
+                                handler(this, System.EventArgs.Empty);
+                        }
+                    }
+                }";
+
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
     }
 }


### PR DESCRIPTION
Related to #160
