### PR TITLE
Fix for CC0020

### DIFF
--- a/src/CSharp/CodeCracker/Refactoring/ParameterRefactoryAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Refactoring/ParameterRefactoryAnalyzer.cs
@@ -29,9 +29,17 @@ namespace CodeCracker
         {
             var method = (MethodDeclarationSyntax)context.Node;
 
+            if (method.Modifiers.Any(SyntaxKind.ExternKeyword)) return;
+
             var contentParameter = method.ParameterList;
 
             if (!contentParameter.Parameters.Any() || contentParameter.Parameters.Count <= 3) return;
+
+            if (contentParameter.Parameters.SelectMany(parameter => parameter.Modifiers)
+                    .Any(modifier => modifier.IsKind(SyntaxKind.RefKeyword) ||
+                                     modifier.IsKind(SyntaxKind.OutKeyword) ||
+                                     modifier.IsKind(SyntaxKind.ThisKeyword) ||
+                                     modifier.IsKind(SyntaxKind.ParamsKeyword))) return;
 
             if (method.Body?.ChildNodes().Count() > 0) return;
 

--- a/test/CSharp/CodeCracker.Test/Refactoring/ParameterRefectoryTest.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/ParameterRefectoryTest.cs
@@ -51,6 +51,103 @@ namespace CodeCracker.Test.Refactoring
 
         }
 
+        [Fact]
+        public async Task WhenMethodHasARefParameterShouldNotSuggestANewClass()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public void Foo(string a, string b, int year, ref string d)
+        {
+
+        }
+    }
+
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task WhenMethodHasAnOutParameterShouldNotSuggestANewClass()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public void Foo(string a, string b, int year, out string d)
+        {
+
+        }
+    }
+
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task WhenMethodHasAThisParameterShouldNotSuggestANewClass()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public void Foo(this string a, string b, int year, string d)
+        {
+
+        }
+    }
+
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task WhenMethodHasAParamsParameterShouldNotSuggestANewClass()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public void Foo(string a, string b, int year, params string[] d)
+        {
+
+        }
+    }
+
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task WhenMethodIsMarkedAsExternShouldNotSuggestANewClass()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        [System.Runtime.InteropServices.DllImport(""dllName"")]
+        public extern void Foo(string a, string b, int year, string d);
+    }
+
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
 
         [Fact]
         public async Task ShouldUpdateParameterToClass()


### PR DESCRIPTION
When adding Code Cracker to my project, I found a bug in CC0020 (You should using 'new class') .

This diagnostic should not be reported for extern methods (used in P/Invoke calls) and when the method has parameters with "ref", "out", "this" or "params" modifier. The code fix introduced a breaking change in these situations.
