### PR TITLE
Fix unnecessary break generation in ConvertToSwitchCodeFix

### DIFF
--- a/src/CSharp/CodeCracker/Style/ConvertToSwitchCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/ConvertToSwitchCodeFixProvider.cs
@@ -103,7 +103,8 @@ namespace CodeCracker.Style
                 result = result.Add(source);
             }
 
-            if (!(result.LastOrDefault() is ReturnStatementSyntax))
+            var lastStatement = result.LastOrDefault();
+            if (!(lastStatement is ReturnStatementSyntax || lastStatement is ThrowStatementSyntax))
             {
                 result = result.Add(SyntaxFactory.BreakStatement());
             }

--- a/test/CSharp/CodeCracker.Test/Style/ConvertToSwitchTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ConvertToSwitchTests.cs
@@ -457,6 +457,70 @@ namespace ConsoleApplication1
         }
 
         [Fact]
+        public async Task FixDoesNotUsesBreakWhenSwitchSectionThrows()
+        {
+            const string test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public async Task Foo(string s)
+        {
+            if (s == ""A"")
+            {
+                DoStuff();
+            }
+            else if (s == ""B"")
+            {
+                DoStuff();
+            }
+            else if (s == ""C"")
+            {
+                DoStuff();
+                DoExtraStuff();
+                throw new Exception();
+            }
+            else
+            {
+                throw new Exception();
+            }
+        }
+    }
+}";
+
+            const string expected = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class TypeName
+    {
+        public async Task Foo(string s)
+        {
+            switch (s)
+            {
+                case ""A"":
+                    DoStuff();
+                    break;
+                case ""B"":
+                    DoStuff();
+                    break;
+                case ""C"":
+                    DoStuff();
+                    DoExtraStuff();
+                    throw new Exception();
+                default:
+                    throw new Exception();
+            }
+        }
+    }
+}";
+            await VerifyCSharpFixAsync(test, expected, formatBeforeCompare: false);
+        }
+
+        [Fact]
         public async Task FixDoesNotRemoveComments()
         {
             const string test = @"


### PR DESCRIPTION
Fix bug in CC019.

This code:

```
if (s == "A")
{
    DoStuff();
}
else if (s == "B")
{
    DoStuff();
}
else if (s == "C")
{
    DoStuff();
}
else
{
    throw new Exception();
}
```

Is converted to:

```
switch (s)
{
    case "A":
        DoStuff();
        break;
    case "B":
        DoStuff();
        break;
    case "C":
        DoStuff();
        break;
    default:
        throw new Exception();
        break;
}
```

This causes a "CS0162: Unreachable code detected" after the throw statement.
