### PR TITLE
Allow members ordering by style cop patterns (Closes #172)

### DIFF
--- a/runTestsCS.ps1
+++ b/runTestsCS.ps1
@@ -5,6 +5,11 @@ $testDllFileName = "CodeCracker.Test.CSharp.dll"
 $Global:testDllFullFileName = "$testDllDirPath$testDllFileName"
 $Global:xunitConsole = "$PSScriptRoot\packages\xunit.runners.2.0.0-beta5-build2785\tools\xunit.console.x86.exe"
 
+if ($testClass -eq "now"){
+    . $Global:xunitConsole "$Global:testDllFullFileName"
+    return
+}
+
 function global:DebounceXunit {
     try {
         if (($(date) - $script:lastRun).TotalMilliseconds -lt 2000) {

--- a/runTestsVB.ps1
+++ b/runTestsVB.ps1
@@ -5,6 +5,11 @@ $testDllFileName = "CodeCracker.Test.VisualBasic.dll"
 $Global:testDllFullFileName = "$testDllDirPath$testDllFileName"
 $Global:xunitConsole = "$PSScriptRoot\packages\xunit.runners.2.0.0-beta5-build2785\tools\xunit.console.x86.exe"
 
+if ($testClass -eq "now"){
+    . $Global:xunitConsole "$Global:testDllFullFileName"
+    return
+}
+
 function global:DebounceXunit {
     try {
         if (($(date) - $script:lastRun).TotalMilliseconds -lt 2000) {

--- a/src/CSharp/CodeCracker/Refactoring/AllowMembersOrderingCodeFixProvider.StyleCop.cs
+++ b/src/CSharp/CodeCracker/Refactoring/AllowMembersOrderingCodeFixProvider.StyleCop.cs
@@ -27,11 +27,11 @@ namespace CodeCracker.Refactoring
         {
             Dictionary<Type, int> typeRank = new Dictionary<Type, int>
             {
-                { typeof(FieldDeclarationSyntax),       1 },
-                { typeof(EventFieldDeclarationSyntax),  2 },
-                { typeof(ConstructorDeclarationSyntax), 3 },
-                { typeof(DestructorDeclarationSyntax),  4 },
-                { typeof(DelegateDeclarationSyntax),    5 },
+                { typeof(FieldDeclarationSyntax),       1 },                
+                { typeof(ConstructorDeclarationSyntax), 2 },
+                { typeof(DestructorDeclarationSyntax),  3 },
+                { typeof(DelegateDeclarationSyntax),    4 },
+                { typeof(EventFieldDeclarationSyntax),  5 },
                 { typeof(EventDeclarationSyntax),       6 },
                 { typeof(EnumDeclarationSyntax),        7 },
                 { typeof(InterfaceDeclarationSyntax),   8 },
@@ -70,11 +70,11 @@ namespace CodeCracker.Refactoring
                 var xModifiers = GetModifiers(x);
                 var yModifiers = GetModifiers(y);
 
-                comparedPoints = GetSpecialModifierPoints(xModifiers).CompareTo(GetSpecialModifierPoints(yModifiers));
+                comparedPoints = GetAccessLevelPoints(xModifiers).CompareTo(GetAccessLevelPoints(yModifiers));
                 if (comparedPoints != 0)
                     return comparedPoints;
 
-                comparedPoints = GetAccessLevelPoints(xModifiers).CompareTo(GetAccessLevelPoints(yModifiers));
+                comparedPoints = GetSpecialModifierPoints(xModifiers).CompareTo(GetSpecialModifierPoints(yModifiers));
                 if (comparedPoints != 0)
                     return comparedPoints;
 

--- a/test/CSharp/CodeCracker.Test/Refactoring/AllowMembersOrderingCodeFixProviderTests.Base.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/AllowMembersOrderingCodeFixProviderTests.Base.cs
@@ -37,6 +37,19 @@ namespace CodeCracker.Test.Refactoring
             Assert.True(codeFixProvider.HasIComparerBeenCalled, "The IComparer must be used to sort the members of that type");
         }
 
+        [Fact]
+        public async Task BaseAllowMembersOrderingShouldNotRegisterFixIfIsAlreadySorted()
+        {
+            var source = @"
+            public class Foo
+            {
+                int a;
+                void B() { }
+            }";
+
+            await VerifyCSharpHasNoFixAsync(source);
+        }
+
         [Theory]
         [InlineData("class")]
         [InlineData("struct")]

--- a/test/CSharp/CodeCracker.Test/Refactoring/AllowMembersOrderingCodeFixProviderTests.StyleCop.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/AllowMembersOrderingCodeFixProviderTests.StyleCop.cs
@@ -30,11 +30,11 @@ namespace CodeCracker.Test.Refactoring
             const string expected = @"
             class Foo
             {
-                public int b = 0;
-                public event System.Action EventField;
+                public int b = 0;                
                 Foo() { }
                 ~Foo() { }
                 public delegate double Delegate();
+                public event System.Action EventField;
                 public event System.Action Event { add { } remove { } }
                 enum Enum { Enum1 }
                 public interface Interface { }
@@ -69,13 +69,13 @@ namespace CodeCracker.Test.Refactoring
             public class Foo
             {
                 public const int z = 0;
-                const int x = 0;
                 public static int v = 0;
-                static int u = 0;
                 public int t = 0;
                 internal int s = 0;
                 protected internal int r = 0;
                 protected int q = 0;
+                const int x = 0;
+                static int u = 0;
                 private int p = 0;
             }";
 
@@ -116,11 +116,11 @@ namespace CodeCracker.Test.Refactoring
             class Foo
             {
                 int a = 0, b = 1;
-                int c = 2, d = 3;
-                event System.Action EventField;
-                event System.Action EventField1;
+                int c = 2, d = 3;        
                 delegate double Delegate();
                 delegate double Delegate2();
+                event System.Action EventField;
+                event System.Action EventField1;
                 event System.Action Event { add { } remove { } }
                 event System.Action Event1 { add { } remove { } }
                 enum Enum { Enum1 }
@@ -191,14 +191,14 @@ namespace CodeCracker.Test.Refactoring
                 {
                     public static string Field1;
                     public string Field;
-                    public event Action EventField;
-                    public event Action EventField1;
                     public Foo()
                     {
                         Property = Field1 = Field = "";
                         EventField = EventField1 = () => { };
                     }
                     public delegate double Delegate(double num);
+                    public event Action EventField;
+                    public event Action EventField1;
                     public event Action Event
                     {
                         add { EventField += value; }


### PR DESCRIPTION
https://github.com/code-cracker/code-cracker/issues/172

I created the BaseAllowMembersOrderingCodeFixProvider in order to increase code reuse as more ordering algorithms are expected in the future. 

Each <NameX>AllowMembersOrderingCodeFixProvider should provides a IComparer in order to put the type members on the correct order and the BaseAllowMembersOrderingCodeFixProvider takes the responsibility to write them.