### PR TITLE
Const fields can't be made readonly

### DIFF
--- a/src/CSharp/CodeCracker/Usage/ReadonlyFieldAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/ReadonlyFieldAnalyzer.cs
@@ -120,7 +120,8 @@ namespace CodeCracker.Usage
                 || !fieldDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)
                     || m.IsKind(SyntaxKind.ProtectedKeyword)
                     || m.IsKind(SyntaxKind.InternalKeyword)
-                    || m.IsKind(SyntaxKind.ReadOnlyKeyword));
+                    || m.IsKind(SyntaxKind.ReadOnlyKeyword)
+                    || m.IsKind(SyntaxKind.ConstKeyword));
         }
 
         private static List<TypeDeclarationSyntax> GetTypesInRoot(SyntaxNode root)

--- a/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
@@ -65,6 +65,20 @@ namespace CodeCracker.Test.Usage
         }
 
         [Fact]
+        public async Task ConstantFieldDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            private const int i = 1;
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task FieldWithAssignmentOnDeclarationCreatesDiagnostic()
         {
             const string source = @"


### PR DESCRIPTION
Fixes CC0052 (Make field readonly) to ignore const fields.