### PR TITLE
Fixes NullReferenceException in CC0047

### DIFF
--- a/src/CSharp/CodeCracker/Style/PropertyPrivateSetAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/PropertyPrivateSetAnalyzer.cs
@@ -39,7 +39,7 @@ namespace CodeCracker.Style
             var invocationExpression = (PropertyDeclarationSyntax)context.Node;
             var semanticModel = context.SemanticModel;
 
-            if (invocationExpression.AccessorList.Accessors.Count == 1) return;
+            if (invocationExpression.AccessorList == null || invocationExpression.AccessorList.Accessors.Count == 1) return;
 
             var setAcessor = (invocationExpression.AccessorList.Accessors[0].Keyword.Text == "set") ? invocationExpression.AccessorList.Accessors[0] : invocationExpression.AccessorList.Accessors[1];
 

--- a/test/CSharp/CodeCracker.Test/Style/PropertyPrivateSetTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/PropertyPrivateSetTests.cs
@@ -46,6 +46,22 @@ namespace CodeCracker.Test.Style
         }
 
         [Fact]
+        public async Task ExpressionBodiedPropertyDoesNotCreateDiagnostic()
+        {
+            const string test = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int MyProperty => 0;
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async Task PropertyPrivateFixAutoProperty()
         {
             const string test = @"


### PR DESCRIPTION
Expression bodied properties don't have an AccessorList, so we need a null check.