### PR TITLE
Analyze CoreFX after tests

### DIFF
--- a/CodeCracker.CSharp.sln
+++ b/CodeCracker.CSharp.sln
@@ -19,9 +19,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
 		buildNuget.cmd = buildNuget.cmd
 		src\CSharp\buildNugetCSharp.cmd = src\CSharp\buildNugetCSharp.cmd
 		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{051F1BE2-9A44-4B84-9DF8-6537852B7BBC}"
+	ProjectSection(SolutionItems) = preProject
+		test\CSharp\AnalyzeCoreFx.ps1 = test\CSharp\AnalyzeCoreFx.ps1
 		runTestsCS.ps1 = runTestsCS.ps1
 	EndProjectSection
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -150,6 +150,7 @@ after_build:
 test_script:
   - C:\projects\code-cracker\packages\xunit.runners.2.0.0-beta5-build2785\tools\xunit.console.x86.exe "C:\projects\code-cracker\test\CSharp\CodeCracker.Test\bin\Debug\CodeCracker.Test.CSharp.dll" -appveyor
   - C:\projects\code-cracker\packages\xunit.runners.2.0.0-beta5-build2785\tools\xunit.console.x86.exe "C:\projects\code-cracker\test\VisualBasic\CodeCracker.Test\bin\Debug\CodeCracker.Test.VisualBasic.dll" -appveyor
+  - powershell -NoProfile -ExecutionPolicy unrestricted -Command ". C:\projects\code-cracker\test\CSharp\AnalyzeCoreFx.ps1"
 
 artifacts:
   - path: src

--- a/src/CSharp/CodeCracker/Design/EmptyCatchBlockAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/EmptyCatchBlockAnalyzer.cs
@@ -20,7 +20,7 @@ namespace CodeCracker.Design
             Title,
             MessageFormat,
             Category,
-            DiagnosticSeverity.Error,
+            DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: Description,
             helpLink: HelpLink.ForDiagnostic(DiagnosticId));

--- a/test/CSharp/AnalyzeCoreFx.ps1
+++ b/test/CSharp/AnalyzeCoreFx.ps1
@@ -1,0 +1,73 @@
+$baseDir =  "$([System.IO.Path]::GetTempPath())$([System.Guid]::NewGuid().ToString().Substring(0,8))"
+$projectDir =  "$baseDir\corefx"
+$logFile = [System.IO.Path]::GetTempFileName()
+$analyzerDll = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..\src\CSharp\CodeCracker\bin\Debug\CodeCracker.CSharp.dll")
+$gitPath = "https://github.com/dotnet/corefx.git"
+#$gitPath = "C:\proj\corefx"
+
+echo "Saving to log file $logFile"
+echo "Analyzer dll is $analyzerDll"
+
+if ($analyzerDll -eq $null)
+{
+    echo "Analyzer dll not found"
+    exit 1
+}
+
+echo "" > $logFile
+
+echo "Creating project directory $projectDir"
+mkdir $projectDir | Out-Null
+
+echo "Clonando corefx"
+git clone --depth 5 $gitPath $projectDir
+if ($LASTEXITCODE -ne 0)
+{
+    echo "Unable to clone corefx, exiting."
+    exit 2
+}
+
+echo "Adding Code Cracker to projects..."
+$csprojs = ls "$projectDir\*.csproj" -Recurse
+if ($csprojs -eq $null)
+{
+    echo "Analyzer dll not found"
+    exit 1
+}
+
+foreach($csproj in $csprojs)
+{
+    echo "Adding analyzer to $($csproj.Name)"
+    [xml]$xmlProj = cat $csproj
+    $itemGroup = $xmlProj.CreateElement("ItemGroup", $xmlProj.Project.xmlns)
+    $analyzer = $xmlProj.CreateElement("Analyzer", $xmlProj.Project.xmlns)
+    $analyzer.SetAttribute("Include", $analyzerDll)
+    $itemGroup.AppendChild($analyzer) | Out-Null
+    $xmlProj.DocumentElement.AppendChild($itemGroup) | Out-Null
+    $xmlProj.Save($csproj.FullName)
+}
+
+echo "Restoring dependencies"
+. "$projectDir\build.cmd" /t:_RestoreBuildTools
+if ($LASTEXITCODE -ne 0)
+{
+    echo "Not possible to restore build tools, stopping."
+}
+
+$slns = ls "$projectDir\*.sln" -Recurse
+echo "Building..."
+foreach($sln in $slns)
+{
+    echo "Building $($sln.FullName)..."
+    msbuild $sln.FullName /t:rebuild /v:detailed >> $logFile
+}
+$ccBuildErrors = cat $logFile | Select-String "info AnalyzerDriver: The Compiler Analyzer 'CodeCracker"
+if ($ccBuildErrors -ne $null)
+{
+    echo "Errors found (see $logFile):"
+    foreach($ccBuildError in $ccBuildErrors)
+    {
+        #echo $ccBuildError.Line
+        Write-Host -ForegroundColor DarkRed "$($ccBuildError.LineNumber) $($ccBuildError.Line)" 
+    }
+}


### PR DESCRIPTION
Issue #100
Updated appveyor build file.

Note:
After analyzing figured that CC0004 (EmptyCatchBlockAnalyzer)
was using Error as severity, and this was not allowing corefx
to build, so we figured it was a common pattern, so it is now
a warning.
