### PR TITLE
Simplify NameOfCodeFixProvider

### DIFF
--- a/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
@@ -36,25 +36,7 @@ namespace CodeCracker.Design
 
         private async Task<Document> MakeNameOfAsync(Document document, LiteralExpressionSyntax stringLiteral, CancellationToken cancelationToken)
         {
-            var methodDeclaration = stringLiteral.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().FirstOrDefault();
-            if (methodDeclaration != null)
-            {
-                var methodParameter = methodDeclaration.ParameterList.Parameters.First();
-
-                return await NewDocument(document, stringLiteral, methodParameter);
-            }
-            else
-            {
-                var constructorDeclaration = stringLiteral.AncestorsAndSelf().OfType<ConstructorDeclarationSyntax>().FirstOrDefault();
-                var constructorParameter = constructorDeclaration.ParameterList.Parameters.First();
-
-                return await NewDocument(document, stringLiteral, constructorParameter);
-            }
-        }
-
-        private async Task<Document> NewDocument(Document document, LiteralExpressionSyntax stringLiteral, ParameterSyntax methodParameter)
-        {
-            var newNameof = SyntaxFactory.ParseExpression("nameof(\{methodParameter.Identifier.Value})")
+            var newNameof = SyntaxFactory.ParseExpression("nameof(\{stringLiteral.Token.ValueText})")
                                     .WithLeadingTrivia(stringLiteral.GetLeadingTrivia())
                                     .WithTrailingTrivia(stringLiteral.GetTrailingTrivia())
                                     .WithAdditionalAnnotations(Formatter.Annotation);

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -182,6 +182,30 @@ public class TypeName
         }
 
         [Fact]
+        public async Task WhenUsingStringLiteralEqualsSecondParameterNameInMethodFixItToNameof()
+        {
+            const string source = @"
+public class TypeName
+{
+    void Foo(string a, string b)
+    {
+        string whatever = ""b"";
+    }
+}";
+
+            const string fixtest = @"
+public class TypeName
+{
+    void Foo(string a, string b)
+    {
+        string whatever = nameof(b);
+    }
+}";
+
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
         public async Task WhenUsingStringLiteralEqualsParameterNameInMethodMustKeepComments()
         {
             const string source = @"


### PR DESCRIPTION
CC0021 is changing:

```csharp
public class TypeName
{
    void Foo(string a, string b)
    {
        string foo = "b";
    }
}
```

To:

```csharp
public class TypeName
{
    void Foo(string a, string b)
    {
        string foo = nameof(a);
    }
}
```

The NameOfCodeFixProvider was getting always the first parameter and using its name to create the nameof expression. But we don't need to look at the parameters, because we know the parameter name is equals to the literal to be replaced.