### PR TITLE
Fix NullReferenceException in ForInArrayAnalyzer (closes #193)

### DIFF
--- a/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
@@ -40,7 +40,7 @@ namespace CodeCracker.Style
             var forBlock = forStatement.Statement as BlockSyntax;
             if (forBlock == null) return;
             var condition = forStatement.Condition as BinaryExpressionSyntax;
-            if (!condition?.IsKind(SyntaxKind.LessThanExpression) ?? false) return;
+            if (condition == null || !condition.IsKind(SyntaxKind.LessThanExpression)) return;
             var arrayAccessor = condition.Right as MemberAccessExpressionSyntax;
             if (arrayAccessor == null) return;
             if (!arrayAccessor.IsKind(SyntaxKind.SimpleMemberAccessExpression)) return;

--- a/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
@@ -46,7 +46,7 @@ namespace CodeCracker.Style
             if (!arrayAccessor.IsKind(SyntaxKind.SimpleMemberAccessExpression)) return;
             var arrayId = context.SemanticModel.GetSymbolInfo(arrayAccessor.Expression).Symbol as ILocalSymbol;
             var literalExpression = forStatement.Declaration.Variables.Single().Initializer.Value as LiteralExpressionSyntax;
-            if (!literalExpression?.IsKind(SyntaxKind.NumericLiteralExpression) ?? false) return;
+            if (literalExpression == null || !literalExpression.IsKind(SyntaxKind.NumericLiteralExpression)) return;
             if (literalExpression.Token.ValueText != "0") return;
             var controlVarId = context.SemanticModel.GetDeclaredSymbol(forStatement.Declaration.Variables.Single());
             var otherUsesOfIndexToken = forBlock.DescendantTokens().Count(t => t.Text == forStatement.Declaration.Variables.Single().Identifier.Text);

--- a/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
@@ -328,6 +328,28 @@ namespace CodeCracker.Test.Style
         }
 
         [Fact]
+        public async Task ForWithDeclarationInitializedWithAnotherVariableDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public void Foo()
+            {
+                var array = new int[] { 0 };
+                var start = 0;
+                for (int i = start; i < array.Length; i++)
+                {
+                    var item = array[i];
+                }
+            }
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task ForInArrayAnalyzerCreatesDiagnostic()
         {
             const string source = @"

--- a/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
@@ -307,6 +307,27 @@ namespace CodeCracker.Test.Style
         }
 
         [Fact]
+        public async Task ForWithoutABinaryConditionDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public void Foo()
+            {
+                var array = new int[] { 0 };
+                for (var i = 0; Bar; i++)
+                {
+                    var item = array[i];
+                }
+            }
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task ForInArrayAnalyzerCreatesDiagnostic()
         {
             const string source = @"


### PR DESCRIPTION
Related to #193. When the for condition is not a BinaryExpressionSyntax, tthe code was basically doing

    if (!null ?? false) return;

And this caused a NullReferenceException in the line 44.

I just added the parentheses, it fixes the bug. But I don't think it's clear enough, I prefer to change to:

    if (condition == null || !condition.IsKind(SyntaxKind.LessThanExpression)) return;

What do you think?