### PR TITLE
make tests work with any culture - refs #182

### DIFF
--- a/src/CSharp/CodeCracker/Usage/UriAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/UriAnalyzer.cs
@@ -12,7 +12,7 @@ namespace CodeCracker.Usage
     {
         public const string DiagnosticId = "CC0063";
         internal const string Title = "Your Uri syntax is wrong.";
-        internal const string MessageFormat = "'{0}'";
+        internal const string MessageFormat = "{0}";
         internal const string Category = SupportedCategories.Usage;
 
         private const string Description = "This diagnostic checks the Uri string and triggers if the parsing fail "


### PR DESCRIPTION
This PR make Uri tests work with any culture and also adds a unit test to validate that it won't return a diagnostic for user created classes named Uri.