### PR TITLE
IPAdressAnalyzer diagnostic id was wrong. CC0063 instead CC0064 - refs #209

### DIFF
--- a/src/CSharp/CodeCracker/Usage/IPAddressAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/IPAddressAnalyzer.cs
@@ -11,7 +11,7 @@ namespace CodeCracker.Usage
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class IPAddressAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "CC0063";
+        public const string DiagnosticId = "CC0064";
         internal const string Title = "Your IP Address syntax is wrong.";
         internal const string MessageFormat = "{0}";
         internal const string Category = SupportedCategories.Usage;


### PR DESCRIPTION
@giggio, the IPAdressAnalyzer was using Uri's diagnostic Id. Do you think that could be the source of the error?