### PR TITLE
fixes #209 - BUG on UriAnalyzer

### DIFF
--- a/src/CSharp/CodeCracker/Usage/UriAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/UriAnalyzer.cs
@@ -43,12 +43,26 @@ namespace CodeCracker.Usage
             var mainConstrutor = new MethodInformation(
                 "Uri",
                 "System.Uri.Uri(string)",
-                args => { new Uri(args[0].ToString()); }
+                args => {
+                    {
+                        if (args[0] == null)
+                        {
+                            return;
+                        }
+                        new Uri(args[0].ToString());
+                    } }
             );
             var constructorWithUriKind = new MethodInformation(
                 "Uri",
                 "System.Uri.Uri(string, System.UriKind)",
-                args => { new Uri(args[0].ToString(), (UriKind)args[1]); }
+                args =>
+                {
+                    if (args[0] == null)
+                    {
+                        return;
+                    }
+                    new Uri(args[0].ToString(), (UriKind)args[1]);
+                }
             );
 
             var checker = new MethodChecker(context, Rule);

--- a/test/CSharp/CodeCracker.Test/Usage/UriAnalyzerTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/UriAnalyzerTests.cs
@@ -59,6 +59,20 @@ namespace ConsoleApplication1
         }
 
         [Fact]
+        public async Task IfUriConstructorUsingNullFoundDoNotCreatesDiagnostic()
+        {
+            var test = string.Format(TestCode, @"var uri = new System.Uri(null)");
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task IfUriConstructorNotUsingLiteralFoundDoNotCreatesDiagnostic()
+        {
+            var test = string.Format(TestCode, @"var uri = new System.Uri(new object().ToString())");
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async Task IfAbbreviatedUriConstructorFoundAndUriIsIncorrectAndItsNotSystemUriDoNotCreatesDiagnostic()
         {
             const string code = @"


### PR DESCRIPTION
I changed the analyzer to ignore when the arg is null.
I could change MethodChecker to do that always, but since some methods do accept null (arg!), I let this responsibility to the caller.