### PR TITLE
Verify arguments' TypeInfo to identify dynamic arguments

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
@@ -192,5 +192,28 @@ namespace CodeCracker.Test.Usage
 
             await VerifyCSharpFixAsync(source, expected);
         }
+
+        [Fact]
+        public async Task WhenCallExtensionMethodWithDynamicArgumentHasNoDiagnostics()
+        {
+            const string source = @"
+                    using System;
+                    using System.Collections.Generic;
+                    using System.Linq;
+
+                    namespace ConsoleApplication1
+                    {
+                        class ExtensionTest
+                        {
+                            void method()
+                            {
+                                var list = new List<int>() { 5, 56, 2, 4, 63, 2 };
+                                dynamic dList = list;
+                                Console.WriteLine(Enumerable.First(dList));
+                            }
+                        }
+                    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
     }
 }


### PR DESCRIPTION
BUG on CC0026: When there is a dynamic don't raise a diagnostic #225