### PR TITLE
throw expression must be inside a catch block

### DIFF
--- a/src/CSharp/CodeCracker/Usage/RethrowExceptionAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/RethrowExceptionAnalyzer.cs
@@ -42,7 +42,8 @@ namespace CodeCracker.Usage
             if (ident == null) return;
             var exSymbol = context.SemanticModel.GetSymbolInfo(ident).Symbol as ILocalSymbol;
             if (exSymbol == null) return;
-            var catchClause = context.Node.Parent.AncestorsAndSelf().OfType<CatchClauseSyntax>().First();
+            var catchClause = context.Node.Parent.AncestorsAndSelf().OfType<CatchClauseSyntax>().FirstOrDefault();
+            if (catchClause == null) return;
             var catchExSymbol = context.SemanticModel.GetDeclaredSymbol(catchClause.Declaration);
             if (!catchExSymbol.Equals(exSymbol)) return;
             var diagnostic = Diagnostic.Create(Rule, throwStatement.GetLocation(), "Don't throw the same exception you caught, you lose the original stack trace.");

--- a/test/CSharp/CodeCracker.Test/Usage/RethrowExceptionTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RethrowExceptionTests.cs
@@ -105,5 +105,24 @@ namespace CodeCracker.Test.Usage
     }";
             await VerifyCSharpFixAsync(sourceWithoutUsingSystem, fixtest, 0);
         }
+
+        [Fact]
+        public async Task WhenThrowingExceptionOutsideAnyCatchBlock()
+        {
+
+            const string fixtest = @"
+                namespace ConsoleApplication1
+                {
+                    class TypeName
+                    {
+                        public async Task Foo()
+                        {
+                            var ex = new ArgumentException(""An Exception"");
+                            throw ex;
+                        }
+                    }
+                }";
+            await VerifyCSharpHasNoDiagnosticsAsync(fixtest);
+        }
     }
 }


### PR DESCRIPTION
Targeting BUG on CC0012: RethrowExceptionAnalyzer throwing "Sequence
contains no elements"