### PR TITLE
Fix RemovePrivateMethodNeverUsed

### DIFF
--- a/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
@@ -46,11 +46,7 @@ namespace CodeCracker.CSharp.Usage
             var typeDeclaration = methodTarget.Parent as TypeDeclarationSyntax;
             if (typeDeclaration == null) return true;
 
-            var hasIdentifier = (from invocation in typeDeclaration
-                                .DescendantNodes()?.OfType<InvocationExpressionSyntax>()
-                                 where invocation != null
-                                 select invocation?.Expression as IdentifierNameSyntax).ToList();
-
+            var hasIdentifier = typeDeclaration.DescendantNodes()?.OfType<IdentifierNameSyntax>();
             if (hasIdentifier == null || !hasIdentifier.Any()) return false;
             return hasIdentifier.Any(a => a != null && a.Identifier.ValueText.Equals(methodTarget?.Identifier.ValueText));
         }

--- a/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
@@ -43,6 +43,24 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
+        public async void WhenPrivateMethodUsedInAttributionDoesNotGenerateDiagnostics()
+        {
+            const string test = @"
+using System;
+
+public class Foo
+{
+    public void PublicFoo()
+    {
+        Action method = PrivateFoo;
+    }
+
+    private void PrivateFoo() { }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async void WhenPrivateMethodDoesNotUsedShouldCreateDiagnostic()
         {
             const string source = @"


### PR DESCRIPTION
Fix RemovePrivateMethodNeverUsed to correctly identify all references to the private method.

This code causes CC0068:

````csharp
using System;

public class Foo
{
    public void PublicFoo()
    {
        Action method = PrivateFoo;
    }

    private void PrivateFoo() { }
}
````

The PrivateFoo method can't be removed in this context.

(This also affects PR #284)