### PR TITLE
Enable fix all for nameof code fix for vb

### DIFF
--- a/src/VisualBasic/CodeCracker/Design/NameOfCodeFixProvider.vb
+++ b/src/VisualBasic/CodeCracker/Design/NameOfCodeFixProvider.vb
@@ -29,24 +29,10 @@ Namespace Design
         End Function
 
         Private Async Function MakeNameOfAsync(document As Document, stringLiteral As LiteralExpressionSyntax, cancellationToken As CancellationToken) As Task(Of Document)
-            Dim methodDeclaration = stringLiteral.AncestorsAndSelf().OfType(Of MethodBlockSyntax).FirstOrDefault
-            If methodDeclaration IsNot Nothing Then
-                Dim methodParam = methodDeclaration.SubOrFunctionStatement.ParameterList.Parameters.First
-                Return Await NewDocument(document, stringLiteral, methodParam, cancellationToken)
-            Else
-                Dim constructorDeclaration = stringLiteral.AncestorsAndSelf.OfType(Of ConstructorBlockSyntax).FirstOrDefault
-                Dim constructorParam = constructorDeclaration.SubNewStatement.ParameterList.Parameters.First
-
-                Return Await NewDocument(document, stringLiteral, constructorParam, cancellationToken)
-            End If
-        End Function
-
-        Private Async Function NewDocument(document As Document, stringLiteral As LiteralExpressionSyntax, methodParameter As ParameterSyntax, cancellationToken As CancellationToken) As Task(Of Document)
-            Dim newNameof = SyntaxFactory.ParseExpression(String.Format("NameOf({0})", methodParameter.Identifier.Identifier.ValueText)).
+            Dim newNameof = SyntaxFactory.ParseExpression(String.Format("NameOf({0})", stringLiteral.Token.ValueText)).
             WithLeadingTrivia(stringLiteral.GetLeadingTrivia).
             WithTrailingTrivia(stringLiteral.GetTrailingTrivia).
             WithAdditionalAnnotations(Formatter.Annotation)
-
             Dim root = Await document.GetSyntaxRootAsync(cancellationToken)
             Dim newRoot = root.ReplaceNode(stringLiteral, newNameof)
             Return document.WithSyntaxRoot(newRoot)

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -254,7 +254,7 @@ public class TypeName
     }
 }";
 
-            await VerifyFixAllAsync(source, fixtest);
+            await VerifyCSharpFixAllAsync(source, fixtest);
         }
 
         [Fact]

--- a/test/CSharp/CodeCracker.Test/Refactoring/SplitIntoNestedIfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/SplitIntoNestedIfTests.cs
@@ -122,7 +122,7 @@ namespace CodeCracker.Test.CSharp.Refactoring
                         }
                     }
                 }".WrapInCSharpMethod();
-            await VerifyFixAllAsync(source, expected);
+            await VerifyCSharpFixAllAsync(source, expected);
         }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
@@ -704,7 +704,7 @@ m.Dispose();".WrapInCSharpMethod();
                     public void Dispose() { }
                 }
 ";
-            await VerifyFixAllAsync(source, fixtest);
+            await VerifyCSharpFixAllAsync(source, fixtest);
         }
 
         [Fact]

--- a/test/CSharp/CodeCracker.Test/Usage/RemoveUnreachableCodeTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemoveUnreachableCodeTest.cs
@@ -336,7 +336,7 @@ class Foo
         return;
     }
 }";
-            await VerifyFixAllAsync(source, fixtest);
+            await VerifyCSharpFixAllAsync(source, fixtest);
         }
 
         [Fact]

--- a/test/VisualBasic/CodeCracker.Test/Design/NameOfTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Design/NameOfTests.vb
@@ -178,5 +178,26 @@ Public Class TypeName
 End Class"
             Await VerifyBasicHasNoDiagnosticsAsync(test)
         End Function
+
+        <Fact>
+        Public Async Function FixAllInDocument() As Task
+            Const source = "
+Public Class TypeName
+    Sub Go(x As Integer, y As Integer, z As Integer)
+        Dim a = ""x""
+        Dim b = ""y""
+        Dim c = ""z""
+    End Sub
+End Class"
+            Const fixtest = "
+Public Class TypeName
+    Sub Go(x As Integer, y As Integer, z As Integer)
+        Dim a = NameOf(x)
+        Dim b = NameOf(y)
+        Dim c = NameOf(z)
+    End Sub
+End Class"
+            Await VerifyBasicFixAllAsync(source, fixtest)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #309
Also creates infrastructure for fix all verification for VB which was missing.