### PR TITLE
Fix bug on object creation for CC0009 (ObjectInitializerAnalyzer)

### DIFF
--- a/src/CSharp/CodeCracker/Style/ObjectInitializerAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ObjectInitializerAnalyzer.cs
@@ -55,7 +55,8 @@ namespace CodeCracker.CSharp.Style
             if (!expressionStatement?.Expression?.IsKind(SyntaxKind.SimpleAssignmentExpression) ?? false) return;
             var assignmentExpression = (AssignmentExpressionSyntax)expressionStatement.Expression;
             var variableSymbol = semanticModel.GetSymbolInfo(assignmentExpression.Left).Symbol;
-            var assignmentExpressions = FindAssingmentExpressions(semanticModel, expressionStatement, variableSymbol);
+            if (!assignmentExpression.Right.IsKind(SyntaxKind.ObjectCreationExpression)) return;
+            var assignmentExpressions = FindAssignmentExpressions(semanticModel, expressionStatement, variableSymbol);
             if (!assignmentExpressions.Any()) return;
 
             var diagnostic = Diagnostic.Create(RuleAssignment, expressionStatement.GetLocation(), "You can use initializers in here.");
@@ -73,14 +74,14 @@ namespace CodeCracker.CSharp.Style
             if (localDeclarationStatement.Declaration.Variables.Count > 1) return;
             var variable = localDeclarationStatement.Declaration.Variables.Single();
             var variableSymbol = semanticModel.GetDeclaredSymbol(variable);
-            var assignmentExpressions = FindAssingmentExpressions(semanticModel, localDeclarationStatement, variableSymbol);
+            var assignmentExpressions = FindAssignmentExpressions(semanticModel, localDeclarationStatement, variableSymbol);
             if (!assignmentExpressions.Any()) return;
 
             var diagnostic = Diagnostic.Create(RuleLocalDeclaration, localDeclarationStatement.GetLocation(), "You can use initializers in here.");
             context.ReportDiagnostic(diagnostic);
         }
 
-        public static List<ExpressionStatementSyntax> FindAssingmentExpressions(SemanticModel semanticModel, StatementSyntax statement, ISymbol variableSymbol)
+        public static List<ExpressionStatementSyntax> FindAssignmentExpressions(SemanticModel semanticModel, StatementSyntax statement, ISymbol variableSymbol)
         {
             var blockParent = statement.FirstAncestorOrSelf<BlockSyntax>();
             var isBefore = true;

--- a/src/CSharp/CodeCracker/Style/ObjectInitializerCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/ObjectInitializerCodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace CodeCracker.CSharp.Style
         private static BlockSyntax CreateNewBlockParent(StatementSyntax statement, SemanticModel semanticModel, ObjectCreationExpressionSyntax objectCreationExpression, ISymbol variableSymbol)
         {
             var blockParent = statement.FirstAncestorOrSelf<BlockSyntax>();
-            var assignmentExpressions = ObjectInitializerAnalyzer.FindAssingmentExpressions(semanticModel, statement, variableSymbol);
+            var assignmentExpressions = ObjectInitializerAnalyzer.FindAssignmentExpressions(semanticModel, statement, variableSymbol);
             var newBlockParent = SyntaxFactory.Block()
                 .WithLeadingTrivia(blockParent.GetLeadingTrivia())
                 .WithTrailingTrivia(blockParent.GetTrailingTrivia())

--- a/test/CSharp/CodeCracker.Test/Style/ObjectInitializerTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ObjectInitializerTests.cs
@@ -165,9 +165,33 @@ namespace CodeCracker.Test.CSharp.Style
     }";
             await VerifyCSharpFixAsync(source, fixtest, 0);
         }
+
+        [Fact]
+        public async Task ObjectCreationWithoutConstructorDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            class Point
+            {
+                public int X { get; set; }
+                public int Y { get; set; }
+            }
+            Point GetPoint() { return null; }
+            void Foo()
+            {
+                var myPoint = GetPoint();
+                myPoint.X = 5;
+            }
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
     }
 
-    public class ObjectInitializerWithAssingmentTests : CodeFixVerifier<ObjectInitializerAnalyzer, ObjectInitializerCodeFixProvider>
+    public class ObjectInitializerWithAssignmentTests : CodeFixVerifier<ObjectInitializerAnalyzer, ObjectInitializerCodeFixProvider>
     {
 
         [Fact]
@@ -298,6 +322,32 @@ namespace CodeCracker.Test.CSharp.Style
         }
     }";
             await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
+        public async Task ObjectCreationWithoutConstructorDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            class Point
+            {
+                public int X { get; set; }
+                public int Y { get; set; }
+            }
+            Point GetPoint() { return null; }
+
+            Point myPoint;
+            void Foo()
+            {
+                myPoint = GetPoint();
+                myPoint.X = 5;
+            }
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
     }
 }


### PR DESCRIPTION
Fixes #315
For some reason we were not checking if the assignment was an `ObjectCreationExprssionSyntax`. Fixed now.
Also fixes errors on the word 'assignment'.
Also add a test to make sure it doesn't happen on `CC0008`. It doesn't.