### PR TITLE
Allow to change culture in a test

### DIFF
--- a/test/CSharp/CodeCracker.Test/ChangeCultureTests.cs
+++ b/test/CSharp/CodeCracker.Test/ChangeCultureTests.cs
@@ -1,0 +1,19 @@
+﻿#pragma warning disable CC0022 //todo: remove this pragma as soon as CC0022 is fixed (issue #319)
+using FluentAssertions;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp
+{
+    public class ChangeCultureTests
+    {
+        [Fact]
+        public void ChangesCulture()
+        {
+            2.5.ToString().Should().Be("2.5");
+            using (new ChangeCulture("pt-BR"))
+                2.5.ToString().Should().Be("2,5");
+            2.5.ToString().Should().Be("2.5");
+        }
+    }
+}
+#pragma warning restore CC0022

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -134,6 +134,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChangeCultureTests.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensionsTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Performance\StringBuilderInLoopTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Refactoring/ComputeExpressionTests.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/ComputeExpressionTests.cs
@@ -63,6 +63,15 @@ namespace CodeCracker.Test.CSharp.Refactoring
             await VerifyCSharpFixAsync(original.WrapInCSharpMethod(), fix.WrapInCSharpMethod());
 
         [Fact]
+        public async Task ComputeExpressionOnADifferentCulture()
+        {
+#pragma warning disable CC0022 //todo: remove this pragma as soon as CC0022 is fixed (issue #319)
+            using (new ChangeCulture("pt-BR"))
+                await VerifyCSharpFixAsync("var a = 1m * (1 + 2) * 3.1m;".WrapInCSharpMethod(), "var a = 9.3;".WrapInCSharpMethod());
+#pragma warning restore CC0022
+        }
+
+        [Fact]
         public async Task IncorrectExpressionDoesNotCreateDiagnostic() =>
             await VerifyCSharpHasNoDiagnosticsAsync("var a = 1m * (1 + 2) * 3.1;".WrapInCSharpMethod());
 

--- a/test/Common/CodeCracker.Test.Common/ChangeCulture.cs
+++ b/test/Common/CodeCracker.Test.Common/ChangeCulture.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeCracker.Test
+{
+    public class ChangeCulture : IDisposable
+    {
+        public ChangeCulture(string cultureName)
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(cultureName);
+            System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(cultureName);
+        }
+
+        public void Dispose()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+            System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/test/Common/CodeCracker.Test.Common/CodeCracker.Test.Common.csproj
+++ b/test/Common/CodeCracker.Test.Common/CodeCracker.Test.Common.csproj
@@ -142,6 +142,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChangeCulture.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />
     <Compile Include="Helpers\DiagnosticResult.cs" />
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />

--- a/test/Common/CodeCracker.Test.Common/Helpers/CodeFixVerifier.Helper.cs
+++ b/test/Common/CodeCracker.Test.Common/Helpers/CodeFixVerifier.Helper.cs
@@ -22,14 +22,14 @@ namespace CodeCracker.Test
         /// <returns>A Document with the changes from the CodeAction</returns>
         private static async Task<Document> ApplyFixAsync(Document document, CodeAction codeAction)
         {
-            var operations = await codeAction.GetOperationsAsync(CancellationToken.None);
+            var operations = await codeAction.GetOperationsAsync(CancellationToken.None).ConfigureAwait(true);
             var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
             return solution.GetDocument(document.Id);
         }
 
         private static async Task<Project> ApplyFixAsync(Project project, CodeAction codeAction)
         {
-            var operations = await codeAction.GetOperationsAsync(CancellationToken.None);
+            var operations = await codeAction.GetOperationsAsync(CancellationToken.None).ConfigureAwait(true);
             var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
             return solution.GetProject(project.Id);
         }
@@ -71,7 +71,7 @@ namespace CodeCracker.Test
         /// <returns>The compiler diagnostics that were found in the code</returns>
         private static async Task<IEnumerable<Diagnostic>> GetCompilerDiagnosticsAsync(Document document)
         {
-            return (await document.GetSemanticModelAsync()).GetDiagnostics();
+            return (await document.GetSemanticModelAsync().ConfigureAwait(true)).GetDiagnostics();
         }
     }
 }

--- a/test/Common/CodeCracker.Test.Common/Helpers/DiagnosticVerifier.Helper.cs
+++ b/test/Common/CodeCracker.Test.Common/Helpers/DiagnosticVerifier.Helper.cs
@@ -43,7 +43,7 @@ namespace CodeCracker.Test
         /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
         private static async Task<Diagnostic[]> GetSortedDiagnosticsAsync(string[] sources, string language, DiagnosticAnalyzer analyzer)
         {
-            return await GetSortedDiagnosticsFromDocumentsAsync(analyzer, GetDocuments(sources, language));
+            return await GetSortedDiagnosticsFromDocumentsAsync(analyzer, GetDocuments(sources, language)).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -63,9 +63,9 @@ namespace CodeCracker.Test
             var diagnostics = new List<Diagnostic>();
             foreach (var project in projects)
             {
-                var compilation = await project.GetCompilationAsync();
+                var compilation = await project.GetCompilationAsync().ConfigureAwait(true);
                 var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer));
-                var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+                var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(true);
                 foreach (var diag in diags)
                 {
                     if (diag.Location == Location.None || diag.Location.IsInMetadata)
@@ -76,7 +76,7 @@ namespace CodeCracker.Test
                     {
                         foreach (var document in project.Documents)
                         {
-                            var tree = await document.GetSyntaxTreeAsync();
+                            var tree = await document.GetSyntaxTreeAsync().ConfigureAwait(true);
                             if (tree == diag.Location.SourceTree) diagnostics.Add(diag);
                         }
                     }
@@ -192,8 +192,8 @@ namespace CodeCracker.Test
         /// <returns>A string contianing the syntax of the Document after formatting</returns>
         public static async Task<string> GetStringFromDocumentAsync(Document document)
         {
-            var simplifiedDoc = await Simplifier.ReduceAsync(document, Simplifier.Annotation);
-            var root = await simplifiedDoc.GetSyntaxRootAsync();
+            var simplifiedDoc = await Simplifier.ReduceAsync(document, Simplifier.Annotation).ConfigureAwait(true);
+            var root = await simplifiedDoc.GetSyntaxRootAsync().ConfigureAwait(true);
             root = Formatter.Format(root, Formatter.Annotation, simplifiedDoc.Project.Solution.Workspace);
             return root.GetText().ToString();
         }
@@ -201,8 +201,8 @@ namespace CodeCracker.Test
         public static async Task<string> FormatSourceAsync(string language, string source)
         {
             var document = CreateDocument(source, language);
-            var newDoc = await Formatter.FormatAsync(document);
-            return (await newDoc.GetSyntaxRootAsync()).ToFullString();
+            var newDoc = await Formatter.FormatAsync(document).ConfigureAwait(true);
+            return (await newDoc.GetSyntaxRootAsync().ConfigureAwait(true)).ToFullString();
         }
     }
 }

--- a/test/Common/CodeCracker.Test.Common/Verifiers/CodeFixVerifier.cs
+++ b/test/Common/CodeCracker.Test.Common/Verifiers/CodeFixVerifier.cs
@@ -38,18 +38,18 @@ namespace CodeCracker.Test
         {
             if (formatBeforeCompare)
             {
-                oldSource = await FormatSourceAsync(LanguageNames.CSharp, oldSource);
-                newSource = await FormatSourceAsync(LanguageNames.CSharp, newSource);
+                oldSource = await FormatSourceAsync(LanguageNames.CSharp, oldSource).ConfigureAwait(true);
+                newSource = await FormatSourceAsync(LanguageNames.CSharp, newSource).ConfigureAwait(true);
             }
             var diagnosticAnalyzer = GetDiagnosticAnalyzer();
             if (diagnosticAnalyzer != null)
             {
-                await VerifyFixAsync(LanguageNames.CSharp, diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+                await VerifyFixAsync(LanguageNames.CSharp, diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics).ConfigureAwait(true);
             }
             else
             {
                 codeFixProvider = codeFixProvider ?? GetCodeFixProvider();
-                await VerifyFixAsync(LanguageNames.CSharp, codeFixProvider.FixableDiagnosticIds, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+                await VerifyFixAsync(LanguageNames.CSharp, codeFixProvider.FixableDiagnosticIds, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics).ConfigureAwait(true);
             }
         }
 
@@ -64,18 +64,18 @@ namespace CodeCracker.Test
         {
             if (formatBeforeCompare)
             {
-                oldSource = await FormatSourceAsync(LanguageNames.VisualBasic, oldSource);
-                newSource = await FormatSourceAsync(LanguageNames.VisualBasic, newSource);
+                oldSource = await FormatSourceAsync(LanguageNames.VisualBasic, oldSource).ConfigureAwait(true);
+                newSource = await FormatSourceAsync(LanguageNames.VisualBasic, newSource).ConfigureAwait(true);
             }
             var diagnosticAnalyzer = GetDiagnosticAnalyzer();
             if (diagnosticAnalyzer != null)
             {
-                await VerifyFixAsync(LanguageNames.VisualBasic, diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+                await VerifyFixAsync(LanguageNames.VisualBasic, diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics).ConfigureAwait(true);
             }
             else
             {
                 codeFixProvider = codeFixProvider ?? GetCodeFixProvider();
-                await VerifyFixAsync(LanguageNames.VisualBasic, codeFixProvider.FixableDiagnosticIds, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+                await VerifyFixAsync(LanguageNames.VisualBasic, codeFixProvider.FixableDiagnosticIds, codeFixProvider, oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics).ConfigureAwait(true);
             }
         }
 
@@ -98,38 +98,38 @@ namespace CodeCracker.Test
             var codeFixFixableDiagnostics = codeFixProvider.FixableDiagnosticIds;
             Assert.True(codeFixFixableDiagnostics.Any(d => supportedDiagnostics.Contains(d)), "Code fix provider does not fix the diagnostic provided by the analyzer.");
             var document = CreateDocument(oldSource, language);
-            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document });
-            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document);
+            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }).ConfigureAwait(true);
+            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true);
             var attempts = analyzerDiagnostics.Length;
 
             for (int i = 0; i < attempts; ++i)
             {
                 var actions = new List<CodeAction>();
                 var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
-                await codeFixProvider.RegisterCodeFixesAsync(context);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(true);
 
                 if (!actions.Any()) break;
 
                 if (codeFixIndex != null)
                 {
-                    document = await ApplyFixAsync(document, actions.ElementAt((int)codeFixIndex));
+                    document = await ApplyFixAsync(document, actions.ElementAt((int)codeFixIndex)).ConfigureAwait(true);
                     break;
                 }
 
-                document = await ApplyFixAsync(document, actions.ElementAt(0));
-                analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document });
+                document = await ApplyFixAsync(document, actions.ElementAt(0)).ConfigureAwait(true);
+                analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }).ConfigureAwait(true);
 
-                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
+                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
 
 
                 //check if applying the code fix introduced any new compiler diagnostics
                 if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 {
                     // Format and get the compiler diagnostics again so that the locations make sense in the output
-                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(), Formatter.Annotation, document.Project.Solution.Workspace));
-                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
+                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync().ConfigureAwait(true), Formatter.Annotation, document.Project.Solution.Workspace));
+                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
 
-                    Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync()).ToFullString()}\r\n");
+                    Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync().ConfigureAwait(true)).ToFullString()}\r\n");
                 }
 
                 //check if there are analyzer diagnostics left after the code fix
@@ -137,14 +137,14 @@ namespace CodeCracker.Test
             }
 
             //after applying all of the code fixes, compare the resulting string to the inputted one
-            var actual = await GetStringFromDocumentAsync(document);
+            var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
             Assert.Equal(newSource, actual);
         }
 
         private async Task VerifyFixAsync(string language, ImmutableArray<string> diagnosticIds, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language);
-            var compilerDiagnostics = (await GetCompilerDiagnosticsAsync(document)).ToList();
+            var compilerDiagnostics = (await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true)).ToList();
             var analyzerDiagnostics = compilerDiagnostics.Where(c => diagnosticIds.Contains(c.Id)).ToList();
             var attempts = analyzerDiagnostics.Count();
 
@@ -152,30 +152,30 @@ namespace CodeCracker.Test
             {
                 var actions = new List<CodeAction>();
                 var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
-                await codeFixProvider.RegisterCodeFixesAsync(context);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(true);
 
                 if (!actions.Any()) break;
 
                 if (codeFixIndex != null)
                 {
-                    document = await ApplyFixAsync(document, actions.ElementAt((int)codeFixIndex));
+                    document = await ApplyFixAsync(document, actions.ElementAt((int)codeFixIndex)).ConfigureAwait(true);
                     break;
                 }
 
-                document = await ApplyFixAsync(document, actions.ElementAt(0));
+                document = await ApplyFixAsync(document, actions.ElementAt(0)).ConfigureAwait(true);
 
-                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
-                compilerDiagnostics = (await GetCompilerDiagnosticsAsync(document)).ToList();
+                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
+                compilerDiagnostics = (await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true)).ToList();
                 analyzerDiagnostics = compilerDiagnostics.Where(c => diagnosticIds.Contains(c.Id)).ToList();
 
                 //check if applying the code fix introduced any new compiler diagnostics
                 if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 {
                     // Format and get the compiler diagnostics again so that the locations make sense in the output
-                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(), Formatter.Annotation, document.Project.Solution.Workspace));
-                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
+                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync().ConfigureAwait(true), Formatter.Annotation, document.Project.Solution.Workspace));
+                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
 
-                    Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync()).ToFullString()}\r\n");
+                    Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync().ConfigureAwait(true)).ToFullString()}\r\n");
                 }
 
                 //check if there are analyzer diagnostics left after the code fix
@@ -183,7 +183,7 @@ namespace CodeCracker.Test
             }
 
             //after applying all of the code fixes, compare the resulting string to the inputted one
-            var actual = await GetStringFromDocumentAsync(document);
+            var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
             Assert.Equal(newSource, actual);
         }
 
@@ -191,21 +191,21 @@ namespace CodeCracker.Test
         {
             if (formatBeforeCompare)
             {
-                oldSources = await Task.WhenAll(oldSources.Select(s => FormatSourceAsync(LanguageNames.CSharp, s)));
-                newSources = await Task.WhenAll(newSources.Select(s => FormatSourceAsync(LanguageNames.CSharp, s)));
+                oldSources = await Task.WhenAll(oldSources.Select(s => FormatSourceAsync(LanguageNames.CSharp, s))).ConfigureAwait(true);
+                newSources = await Task.WhenAll(newSources.Select(s => FormatSourceAsync(LanguageNames.CSharp, s))).ConfigureAwait(true);
             }
             var diagnosticAnalyzer = GetDiagnosticAnalyzer();
             if (diagnosticAnalyzer != null)
-                await VerifyFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSources, newSources, allowNewCompilerDiagnostics);
+                await VerifyFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSources, newSources, allowNewCompilerDiagnostics).ConfigureAwait(true);
             else
-                await VerifyFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSources, newSources, allowNewCompilerDiagnostics);
+                await VerifyFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSources, newSources, allowNewCompilerDiagnostics).ConfigureAwait(true);
         }
 
         private async Task VerifyFixAllAsync(DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string[] oldSources, string[] newSources, bool allowNewCompilerDiagnostics)
         {
             var project = CreateProject(oldSources, LanguageNames.CSharp);
-            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, project.Documents.ToArray());
-            var compilerDiagnostics = (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d)))).SelectMany(d => d);
+            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, project.Documents.ToArray()).ConfigureAwait(true);
+            var compilerDiagnostics = (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d))).ConfigureAwait(true)).SelectMany(d => d);
 
             var fixAllProvider = codeFixProvider.GetFixAllProvider();
             var fixAllContext = NewFixAllContext(null, project, codeFixProvider, FixAllScope.Solution,
@@ -215,13 +215,13 @@ namespace CodeCracker.Test
                 (theProject, b, diagnosticIds, cancelationToken) => Task.FromResult((IEnumerable<Diagnostic>)analyzerDiagnostics), //todo: verify, probably wrong
                 CancellationToken.None);
 
-            var action = await fixAllProvider.GetFixAsync(fixAllContext);
+            var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(true);
             if (action == null) throw new Exception("No action supplied for the code fix.");
 
-            project = await ApplyFixAsync(project, action);
+            project = await ApplyFixAsync(project, action).ConfigureAwait(true);
 
             //check if applying the code fix introduced any new compiler diagnostics
-            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d)))).SelectMany(d => d));
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d))).ConfigureAwait(true)).SelectMany(d => d));
             if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n");
 
@@ -229,7 +229,7 @@ namespace CodeCracker.Test
             for (int i = 0; i < docs.Length; i++)
             {
                 var document = docs[i];
-                var actual = await GetStringFromDocumentAsync(document);
+                var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
                 Assert.Equal(newSources[i], actual);
             }
         }
@@ -238,16 +238,16 @@ namespace CodeCracker.Test
         {
             var diagnosticIds = codeFixProvider.FixableDiagnosticIds;
             var project = CreateProject(oldSources, LanguageNames.CSharp);
-            var compilerDiagnostics = (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d)))).SelectMany(d => d);
+            var compilerDiagnostics = (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d))).ConfigureAwait(true)).SelectMany(d => d);
             Func<Document, Task<IEnumerable<Diagnostic>>> getDocumentDiagnosticsAsync = async doc =>
             {
-                var compilerDiags = await GetCompilerDiagnosticsAsync(doc);
+                var compilerDiags = await GetCompilerDiagnosticsAsync(doc).ConfigureAwait(true);
                 return compilerDiags.Where(d => diagnosticIds.Contains(d.Id));
             };
             Func<Project, bool, Task<IEnumerable<Diagnostic>>> getProjectDiagnosticsAsync = async (proj, b) =>
             {
                 var theDocs = proj.Documents;
-                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d)));
+                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d))).ConfigureAwait(true);
                 return diags.SelectMany(d => d);
             };
             var fixAllProvider = codeFixProvider.GetFixAllProvider();
@@ -258,13 +258,13 @@ namespace CodeCracker.Test
                 (theProject, b, diagIds, cancelationToken) => getProjectDiagnosticsAsync(theProject, b),
                 CancellationToken.None);
 
-            var action = await fixAllProvider.GetFixAsync(fixAllContext);
+            var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(true);
             if (action == null) throw new Exception("No action supplied for the code fix.");
 
-            project = await ApplyFixAsync(project, action);
+            project = await ApplyFixAsync(project, action).ConfigureAwait(true);
 
             //check if applying the code fix introduced any new compiler diagnostics
-            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d)))).SelectMany(d => d));
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, (await Task.WhenAll(project.Documents.Select(d => GetCompilerDiagnosticsAsync(d))).ConfigureAwait(true)).SelectMany(d => d));
             if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n");
 
@@ -272,7 +272,7 @@ namespace CodeCracker.Test
             for (int i = 0; i < docs.Length; i++)
             {
                 var document = docs[i];
-                var actual = await GetStringFromDocumentAsync(document);
+                var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
                 Assert.Equal(newSources[i], actual);
             }
         }
@@ -281,46 +281,46 @@ namespace CodeCracker.Test
         {
             if (formatBeforeCompare)
             {
-                oldSource = await FormatSourceAsync(LanguageNames.CSharp, oldSource);
-                newSource = await FormatSourceAsync(LanguageNames.CSharp, newSource);
+                oldSource = await FormatSourceAsync(LanguageNames.CSharp, oldSource).ConfigureAwait(true);
+                newSource = await FormatSourceAsync(LanguageNames.CSharp, newSource).ConfigureAwait(true);
             }
             var diagnosticAnalyzer = GetDiagnosticAnalyzer();
             if (diagnosticAnalyzer != null)
-                await VerifyCSharpFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics);
+                await VerifyCSharpFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
             else
-                await VerifyCSharpFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics);
+                await VerifyCSharpFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
         }
 
         protected async Task VerifyBasicFixAllAsync(string oldSource, string newSource, bool allowNewCompilerDiagnostics = false, bool formatBeforeCompare = true, CodeFixProvider codeFixProvider = null)
         {
             if (formatBeforeCompare)
             {
-                oldSource = await FormatSourceAsync(LanguageNames.VisualBasic, oldSource);
-                newSource = await FormatSourceAsync(LanguageNames.VisualBasic, newSource);
+                oldSource = await FormatSourceAsync(LanguageNames.VisualBasic, oldSource).ConfigureAwait(true);
+                newSource = await FormatSourceAsync(LanguageNames.VisualBasic, newSource).ConfigureAwait(true);
             }
             var diagnosticAnalyzer = GetDiagnosticAnalyzer();
             if (diagnosticAnalyzer != null)
-                await VerifyBasicFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics);
+                await VerifyBasicFixAllAsync(diagnosticAnalyzer, codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
             else
-                await VerifyBasicFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics);
+                await VerifyBasicFixAllAsync(codeFixProvider ?? GetCodeFixProvider(), oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
         }
 
         private async Task VerifyBasicFixAllAsync(DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics) =>
-            await VerifyFixAllAsync(LanguageNames.VisualBasic, analyzer, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics);
+            await VerifyFixAllAsync(LanguageNames.VisualBasic, analyzer, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
 
         private async Task VerifyCSharpFixAllAsync(DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics) =>
-            await VerifyFixAllAsync(LanguageNames.CSharp, analyzer, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics);
+            await VerifyFixAllAsync(LanguageNames.CSharp, analyzer, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
 
         private async Task VerifyFixAllAsync(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language);
-            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document);
+            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true);
             Func<Document, Task<IEnumerable<Diagnostic>>> getDocumentDiagnosticsAsync = async doc =>
-                await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { doc });
+                await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { doc }).ConfigureAwait(true);
             Func<Project, bool, Task<IEnumerable<Diagnostic>>> getProjectDiagnosticsAsync = async (proj, b) =>
             {
                 var theDocs = proj.Documents;
-                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d)));
+                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d))).ConfigureAwait(true);
                 return diags.SelectMany(d => d);
             };
 
@@ -332,45 +332,45 @@ namespace CodeCracker.Test
                 (theProject, b, diagIds, cancelationToken) => getProjectDiagnosticsAsync(theProject, b),
                 CancellationToken.None);
 
-            var action = await fixAllProvider.GetFixAsync(fixAllContext);
+            var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(true);
             if (action == null) throw new Exception("No action supplied for the code fix.");
 
-            document = await ApplyFixAsync(document, action);
+            document = await ApplyFixAsync(document, action).ConfigureAwait(true);
 
             //check if applying the code fix introduced any new compiler diagnostics
-            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
             if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
             {
                 // Format and get the compiler diagnostics again so that the locations make sense in the output
-                document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(), Formatter.Annotation, document.Project.Solution.Workspace));
-                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
-                Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync()).ToFullString()}\r\n");
+                document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync().ConfigureAwait(true), Formatter.Annotation, document.Project.Solution.Workspace));
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
+                Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync().ConfigureAwait(true)).ToFullString()}\r\n");
             }
 
-            var actual = await GetStringFromDocumentAsync(document);
+            var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
             Assert.Equal(newSource, actual);
         }
 
         private async Task VerifyBasicFixAllAsync(CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics) =>
-            await VerifyFixAllAsync(LanguageNames.VisualBasic, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics);
+            await VerifyFixAllAsync(LanguageNames.VisualBasic, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
 
         private async Task VerifyCSharpFixAllAsync(CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics) =>
-            await VerifyFixAllAsync(LanguageNames.CSharp, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics);
+            await VerifyFixAllAsync(LanguageNames.CSharp, codeFixProvider, oldSource, newSource, allowNewCompilerDiagnostics).ConfigureAwait(true);
 
         private async Task VerifyFixAllAsync(string language, CodeFixProvider codeFixProvider, string oldSource, string newSource, bool allowNewCompilerDiagnostics)
         {
             var diagnosticIds = codeFixProvider.FixableDiagnosticIds;
             var document = CreateDocument(oldSource, language);
-            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document);
+            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true);
             Func<Document, Task<IEnumerable<Diagnostic>>> getDocumentDiagnosticsAsync = async doc =>
             {
-                var compilerDiags = await GetCompilerDiagnosticsAsync(doc);
+                var compilerDiags = await GetCompilerDiagnosticsAsync(doc).ConfigureAwait(true);
                 return compilerDiags.Where(d => diagnosticIds.Contains(d.Id));
             };
             Func<Project, bool, Task<IEnumerable<Diagnostic>>> getProjectDiagnosticsAsync = async (proj, b) =>
             {
                 var theDocs = proj.Documents;
-                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d)));
+                var diags = await Task.WhenAll(theDocs.Select(d => getDocumentDiagnosticsAsync(d))).ConfigureAwait(true);
                 return diags.SelectMany(d => d);
             };
             var fixAllProvider = codeFixProvider.GetFixAllProvider();
@@ -381,22 +381,22 @@ namespace CodeCracker.Test
                 (theProject, b, diagIds, cancelationToken) => getProjectDiagnosticsAsync(theProject, b),
                 CancellationToken.None);
 
-            var action = await fixAllProvider.GetFixAsync(fixAllContext);
+            var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(true);
             if (action == null) throw new Exception("No action supplied for the code fix.");
 
-            document = await ApplyFixAsync(document, action);
+            document = await ApplyFixAsync(document, action).ConfigureAwait(true);
 
             //check if applying the code fix introduced any new compiler diagnostics
-            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
             if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
             {
                 // Format and get the compiler diagnostics again so that the locations make sense in the output
-                document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(), Formatter.Annotation, document.Project.Solution.Workspace));
-                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
-                Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync()).ToFullString()}\r\n");
+                document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync().ConfigureAwait(true), Formatter.Annotation, document.Project.Solution.Workspace));
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(true));
+                Assert.True(false, $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{(await document.GetSyntaxRootAsync().ConfigureAwait(true)).ToFullString()}\r\n");
             }
 
-            var actual = await GetStringFromDocumentAsync(document);
+            var actual = await GetStringFromDocumentAsync(document).ConfigureAwait(true);
             Assert.Equal(newSource, actual);
         }
 
@@ -414,7 +414,7 @@ namespace CodeCracker.Test
         /// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
         protected async Task VerifyCSharpHasNoFixAsync(string source, CodeFixProvider codeFixProvider = null)
         {
-            await VerifyHasNoFixAsync(LanguageNames.CSharp, GetDiagnosticAnalyzer(), codeFixProvider ?? GetCodeFixProvider(), source);
+            await VerifyHasNoFixAsync(LanguageNames.CSharp, GetDiagnosticAnalyzer(), codeFixProvider ?? GetCodeFixProvider(), source).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -429,13 +429,13 @@ namespace CodeCracker.Test
         private async Task VerifyHasNoFixAsync(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string source)
         {
             var document = CreateDocument(source, language);
-            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document });
+            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }).ConfigureAwait(true);
 
             foreach (var analyzerDiagnostic in analyzerDiagnostics)
             {
                 var actions = new List<CodeAction>();
                 var context = new CodeFixContext(document, analyzerDiagnostic, (a, d) => actions.Add(a), CancellationToken.None);
-                await codeFixProvider.RegisterCodeFixesAsync(context);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(true);
                 Assert.False(actions.Any(), $"Should not have a code fix registered for diagnostic '{analyzerDiagnostic.Id}'");
             }
         }

--- a/test/Common/CodeCracker.Test.Common/Verifiers/DiagnosticVerifier.cs
+++ b/test/Common/CodeCracker.Test.Common/Verifiers/DiagnosticVerifier.cs
@@ -26,16 +26,16 @@ namespace CodeCracker.Test
     public abstract partial class DiagnosticVerifier
     {
         protected async Task VerifyBasicHasNoDiagnosticsAsync(string source) =>
-            await VerifyBasicDiagnosticAsync(source);
+            await VerifyBasicDiagnosticAsync(source).ConfigureAwait(true);
 
         protected async Task VerifyBasicHasNoDiagnosticsAsync(params string[] sources) =>
-            await VerifyBasicDiagnosticAsync(sources);
+            await VerifyBasicDiagnosticAsync(sources).ConfigureAwait(true);
 
         protected async Task VerifyCSharpHasNoDiagnosticsAsync(string source) =>
-            await VerifyCSharpDiagnosticAsync(source);
+            await VerifyCSharpDiagnosticAsync(source).ConfigureAwait(true);
 
         protected async Task VerifyCSharpHasNoDiagnosticsAsync(params string[] sources) =>
-            await VerifyCSharpDiagnosticAsync(sources);
+            await VerifyCSharpDiagnosticAsync(sources).ConfigureAwait(true);
 
         /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
@@ -50,7 +50,7 @@ namespace CodeCracker.Test
         /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
         protected async Task VerifyCSharpDiagnosticAsync(string source, params DiagnosticResult[] expected)
         {
-            await VerifyDiagnosticsAsync(new[] { source }, LanguageNames.CSharp, GetDiagnosticAnalyzer(), expected);
+            await VerifyDiagnosticsAsync(new[] { source }, LanguageNames.CSharp, GetDiagnosticAnalyzer(), expected).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace CodeCracker.Test
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
         protected async Task VerifyBasicDiagnosticAsync(string source, params DiagnosticResult[] expected)
         {
-            await VerifyDiagnosticsAsync(new[] { source }, LanguageNames.VisualBasic, GetDiagnosticAnalyzer(), expected);
+            await VerifyDiagnosticsAsync(new[] { source }, LanguageNames.VisualBasic, GetDiagnosticAnalyzer(), expected).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace CodeCracker.Test
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
         protected async Task VerifyCSharpDiagnosticAsync(string[] sources, params DiagnosticResult[] expected)
         {
-            await VerifyDiagnosticsAsync(sources, LanguageNames.CSharp, GetDiagnosticAnalyzer(), expected);
+            await VerifyDiagnosticsAsync(sources, LanguageNames.CSharp, GetDiagnosticAnalyzer(), expected).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace CodeCracker.Test
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
         protected async Task VerifyBasicDiagnosticAsync(string[] sources, params DiagnosticResult[] expected)
         {
-            await VerifyDiagnosticsAsync(sources, LanguageNames.VisualBasic, GetDiagnosticAnalyzer(), expected);
+            await VerifyDiagnosticsAsync(sources, LanguageNames.VisualBasic, GetDiagnosticAnalyzer(), expected).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace CodeCracker.Test
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
         private async Task VerifyDiagnosticsAsync(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
         {
-            var diagnostics = await GetSortedDiagnosticsAsync(sources, language, analyzer);
+            var diagnostics = await GetSortedDiagnosticsAsync(sources, language, analyzer).ConfigureAwait(true);
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
         }
 


### PR DESCRIPTION
Closes #313, which describes the issue in more detail.

It adds the `ChangeCulture` class which changes the current culture
during a test. It enables testing on specific cultures, that were harder
to test before. It is a simple wrap on the current culture property on
the current thread.
I also added on every await on the base and helper test classes a
`.ConfigureAwait(true)` so that every test always returns on the same
thread as it started. If we did not do this then the thread that
continues a test may be different from the one that started it, causing
a problem on the current culture setting.