### PR TITLE
Fix bug where selected overload would change on CC0026

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/CallExtensionMethodAsExtensionTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;
+
 namespace CodeCracker.Test.CSharp.Usage
 {
     public class CallExtensionMethodAsExtensionTests :
@@ -212,6 +213,25 @@ namespace CodeCracker.Test.CSharp.Usage
                             }
                         }
                     }";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task WhenTheSelectedMethodWouldChangeThenCreatesNoDiagnostics()
+        {
+            const string source = @"
+using System.Linq;
+using System.Collections.Generic;
+public static class ExtensionsTestCase
+{
+    public static void Select(this IEnumerable<string> strings, System.Func<string, bool> mySelector)
+    {
+    }
+    public static void UsesSelect()
+    {
+        Enumerable.Select(new[] { """" }, s => s == """");
+    }
+}";
             await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
     }


### PR DESCRIPTION
closes #262
Verifying on a speculative model if selected overload would change and not even raising analyzer.
Changes in code fix are not related to the bug, but are refactorings. The focus of the update is the analyzer, that is not raising the diagnostic anymore.