### PR TITLE
Test with verbatim identifier NameOfCodeFixProvider (#198)

### DIFF
--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -41,8 +41,9 @@ namespace CodeCracker.CSharp.Design
             var attribute = stringLiteral.FirstAncestorOfType<AttributeSyntax>();
             var method = stringLiteral.FirstAncestorOfType(typeof(MethodDeclarationSyntax), typeof(ConstructorDeclarationSyntax)) as BaseMethodDeclarationSyntax;
             if (attribute != null && method.AttributeLists.Any(a => a.Attributes.Contains(attribute))) return;
-            if (!AreEqual(stringLiteral, parameters)) return;
-            var diagnostic = Diagnostic.Create(Rule, stringLiteral.GetLocation(), stringLiteral.Token.Value);
+            var parameter = GetParameterWithIdentifierEqualToStringLiteral(stringLiteral, parameters);
+            if (parameter == null) return;
+            var diagnostic = Diagnostic.Create(Rule, stringLiteral.GetLocation(), parameter.Identifier.Text);
             context.ReportDiagnostic(diagnostic);
         }
 
@@ -64,7 +65,7 @@ namespace CodeCracker.CSharp.Design
             return parameters;
         }
 
-        private bool AreEqual(LiteralExpressionSyntax stringLiteral, SeparatedSyntaxList<ParameterSyntax> parameters) =>
-            parameters.Any(m => m.Identifier.Value.ToString() == stringLiteral.Token.Value.ToString());
+        private ParameterSyntax GetParameterWithIdentifierEqualToStringLiteral(LiteralExpressionSyntax stringLiteral, SeparatedSyntaxList<ParameterSyntax> parameters) =>
+            parameters.FirstOrDefault(m => m.Identifier.Value.ToString() == stringLiteral.Token.Value.ToString());
     }
 }

--- a/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -26,12 +27,19 @@ namespace CodeCracker.CSharp.Design
             var diagnosticSpan = diagnostic.Location.SourceSpan;
             var stringLiteral = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<LiteralExpressionSyntax>().FirstOrDefault();
             if (stringLiteral != null)
-                context.RegisterCodeFix(CodeAction.Create("Use nameof()", c => MakeNameOfAsync(context.Document, stringLiteral, c)), diagnostic);
+            {
+                var parameter = FindParameterThatStringLiteralRefers(root, diagnosticSpan.Start, stringLiteral);
+                if (parameter != null)
+                {
+                    var nameofArgument = parameter.Identifier.Text;
+                    context.RegisterCodeFix(CodeAction.Create("Use nameof()", c => MakeNameOfAsync(context.Document, nameofArgument, stringLiteral, c)), diagnostic);
+                }
+            }
         }
 
-        private async Task<Document> MakeNameOfAsync(Document document, LiteralExpressionSyntax stringLiteral, CancellationToken cancelationToken)
+        private async Task<Document> MakeNameOfAsync(Document document, string nameofArgument, LiteralExpressionSyntax stringLiteral, CancellationToken cancelationToken)
         {
-            var newNameof = SyntaxFactory.ParseExpression($"nameof({stringLiteral.Token.ValueText})")
+            var newNameof = SyntaxFactory.ParseExpression($"nameof({nameofArgument})")
                                     .WithLeadingTrivia(stringLiteral.GetLeadingTrivia())
                                     .WithTrailingTrivia(stringLiteral.GetTrailingTrivia())
                                     .WithAdditionalAnnotations(Formatter.Annotation);
@@ -39,6 +47,13 @@ namespace CodeCracker.CSharp.Design
             var root = await document.GetSyntaxRootAsync(cancelationToken);
             var newRoot = root.ReplaceNode(stringLiteral, newNameof);
             return document.WithSyntaxRoot(newRoot);
+        }
+
+        private ParameterSyntax FindParameterThatStringLiteralRefers(SyntaxNode root, int diagnosticSpanStart, LiteralExpressionSyntax stringLiteral)
+        {
+            var method = root.FindToken(diagnosticSpanStart).Parent.FirstAncestorOfType(typeof(ConstructorDeclarationSyntax), typeof(MethodDeclarationSyntax)) as BaseMethodDeclarationSyntax;
+
+            return method?.ParameterList.Parameters.FirstOrDefault(m => m.Identifier.Value.ToString() == stringLiteral.Token.Value.ToString());
         }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -104,6 +104,92 @@ public class TypeName
         }
 
         [Fact]
+        public async Task WhenUsingVerbatimSpecifierWithKeywordEqualsParameterNameReturnAnalyzerCreatesDiagnostic()
+        {
+            const string source = @"
+public class TypeName
+{
+    void Foo(string @for)
+    {
+        string whatever = ""for"";
+    }
+}
+";
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.NameOf.ToDiagnosticId(),
+                Message = "Use 'nameof(@for)' instead of specifying the parameter name.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 27) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenUsingVerbatimSpecifierWithSimpleIdentifierEqualsParameterNameReturnAnalyzerCreatesDiagnostic()
+        {
+            const string source = @"
+public class TypeName
+{
+    void Foo(string @xyz)
+    {
+        string whatever = ""xyz"";
+    }
+}
+";
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.NameOf.ToDiagnosticId(),
+                Message = "Use 'nameof(@xyz)' instead of specifying the parameter name.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 27) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task FixWithVerbatimIdentifiers()
+        {
+            const string source = @"
+public class TypeName
+{
+    public TypeName(int @object)
+    {
+        var name = ""object"";
+    }
+
+    void Foo(string a, int @for, string b, object @int)
+    {
+        var whatever = ""for"";
+        var whatever1 = ""b"";
+        var whatever2 = ""a"";
+        var whatever3 = ""int"";
+    }
+}";
+
+            const string fixtest = @"
+public class TypeName
+{
+    public TypeName(int @object)
+    {
+        var name = nameof(@object);
+    }
+
+    void Foo(string a, int @for, string b, object @int)
+    {
+        var whatever = nameof(@for);
+        var whatever1 = nameof(b);
+        var whatever2 = nameof(a);
+        var whatever3 = nameof(@int);
+    }
+}";
+
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
         public async Task WhenUsingStringLiteralEqualsParameterNameInConstructorFixItToNameof()
         {
             const string source = @"


### PR DESCRIPTION
Regarding to #198 I added tests to NameOfCodeFixProvider with verbatim identifier.

It turns out that NameOf doesn't work correctly with verbatim identifier.

NameOfCodeFixProvider changed this code:
```csharp
        void Foo(string @for)
        {
            string whatever = "for";
        }
```
to following:
```csharp
        void Foo(string @for)
        {
            string whatever = nameof(for);
        }
```

So I changed NameOfCode(Analyzer/FixProvider) to take nameof argument from identifier that the string literal refers and now NameOf seems working correctly.