### PR TITLE
Fix bug where CC0056 classifies a valid format string as a faulty one.

### DIFF
--- a/src/CSharp/CodeCracker/Usage/StringFormatArgsAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/StringFormatArgsAnalyzer.cs
@@ -45,7 +45,8 @@ namespace CodeCracker.CSharp.Usage
             if (memberSymbol.ToString() == "string.Format(string, params object[])" && argumentList.Arguments.Skip(1).Any(a => context.SemanticModel.GetTypeInfo(a.Expression).Type.TypeKind == TypeKind.Array)) return;
             var formatLiteral = (LiteralExpressionSyntax)argumentList.Arguments[0].Expression;
             var analyzingInterpolation = (InterpolatedStringExpressionSyntax)SyntaxFactory.ParseExpression($"${formatLiteral.Token.Text}");
-            if (analyzingInterpolation.Contents.Count(c => c.IsKind(SyntaxKind.Interpolation)) == argumentList.Arguments.Count - 1) return;
+            var allInterpolations = analyzingInterpolation.Contents.Where(c => c.IsKind(SyntaxKind.Interpolation)).Select(c => (InterpolationSyntax)c);
+            if (allInterpolations.Select(c => c.Expression.ToString()).Distinct().Count() == argumentList.Arguments.Count - 1) return;
             var diag = Diagnostic.Create(Rule, invocationExpression.GetLocation());
             context.ReportDiagnostic(diag);
         }

--- a/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
@@ -114,6 +114,34 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
+        public async Task MethodWithParamtersReferencingSingleArgumentDoesNotCreateDiagnostic()
+        {
+            var source = @"var result = string.Format(""one {0} two {0}"", ""a"");".WrapInCSharpMethod();
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task MethodWithParamtersReferencingSingleAndFormatSpecifiersArgumentDoesNotCreateDiagnostic()
+        {
+            var source = @"var result = string.Format(""PI {0:0.##} PI as Percent {0:P}"", Math.PI);".WrapInCSharpMethod();
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task MethodWithMultibleParamtersReferencingSingleArgumentCreatesDiagnostic()
+        {
+            var source = @"var result = string.Format(""one {0} two {0}"", ""a"", ""b"");".WrapInCSharpMethod();
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
+                Message = StringFormatArgsAnalyzer.MessageFormat,
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
         public async Task IgnoreStringFormatWithCorrectNumberOfParameters()
         {
             var source = @"


### PR DESCRIPTION
This PR fixes issue #333 and #330. 
- CC0056 no longer classifies a valid format string as a faulty one.
- Added 3 new test to cover the scenario described in the issue. 
  - Tested both with and without format specifiers, `{0}` and `{0:P}`.