### PR TITLE
C# CC0021 analyzer expand scope

### DIFF
--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -59,42 +59,9 @@
                 var symbol = semanticModel.LookupSymbols(stringLiteral.Token.SpanStart, null, literalValueText).FirstOrDefault();
 
                 programElementName = symbol?.ToDisplayParts().LastOrDefault(IncludeOnlyPartsThatAreName).ToString();
-
-                if(!Found(programElementName))
-                {
-                    symbol = GetNamespaceSymbolThatEqualsStringLiteral(stringLiteral, semanticModel);
-
-                    if(symbol != null)
-                    {
-                        programElementName = literalValueText;
-                    }
-                }
             }
 
             return programElementName;
-        }
-
-        private static ISymbol GetNamespaceSymbolThatEqualsStringLiteral(LiteralExpressionSyntax stringLiteral, SemanticModel semanticModel)
-        {
-            ISymbol result = null;
-            var valueText = stringLiteral.Token.ValueText;
-            if (valueText.IndexOf(DotChar) > 0)
-            {
-                var lastPartNamespaceStartIndex = valueText.LastIndexOf(DotChar);
-                if (lastPartNamespaceStartIndex + 1 <= valueText.Length)
-                {
-                    var lastPartNamespace = valueText.Substring(lastPartNamespaceStartIndex + 1);
-
-                    var namespaceSymbol = semanticModel.LookupNamespacesAndTypes(stringLiteral.Token.SpanStart, null, lastPartNamespace).FirstOrDefault();
-
-                    if(namespaceSymbol != null && IsStringLiteralProperPartOfNamespaceName(valueText, namespaceSymbol.ToDisplayString()))
-                    {
-                        result = namespaceSymbol;
-                    }
-                }
-            }
-
-            return result;
         }
 
         private static string GetParameterNameThatMatchStringLiteral(LiteralExpressionSyntax stringLiteral)
@@ -129,31 +96,6 @@
             }
 
             return parameterName;
-        }
-
-        private static bool IsStringLiteralProperPartOfNamespaceName(string stringLiteral, string namespaceName)
-        {
-            var result = false;
-
-            var lastOccurence = namespaceName.LastIndexOf(stringLiteral, StringComparison.Ordinal);
-            var areStringsSameLength = stringLiteral.Length == namespaceName.Length;
-
-            if (!areStringsSameLength || lastOccurence >= 0)
-            {
-                var previousCharEqualsDot = lastOccurence > 0 ? namespaceName[lastOccurence - 1].Equals(DotChar) : true;
-
-                var nextCharIndex = lastOccurence + stringLiteral.Length;
-                var nextCharIndexExists = nextCharIndex < namespaceName.Length;
-                var nextCharEqualsDot = nextCharIndexExists ? namespaceName[nextCharIndex].Equals(DotChar) : true;
-
-                result = previousCharEqualsDot || nextCharEqualsDot;
-            }
-            else
-            {
-                result = lastOccurence >= 0;
-            }
-
-            return result;
         }
 
         private static bool Found(string programElement) => !string.IsNullOrEmpty(programElement);

--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -25,7 +25,7 @@
             MessageFormat,
             Category,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: false,
+            isEnabledByDefault: true,
             description: Description,
             helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.NameOf));
 

--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -1,71 +1,167 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
-using System.Collections.Immutable;
-using System.Linq;
-
-namespace CodeCracker.CSharp.Design
+﻿namespace CodeCracker.CSharp.Design
 {
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NameOfAnalyzer : DiagnosticAnalyzer
     {
-        internal const string Title = "You should use nameof instead of the parameter string";
-        internal const string MessageFormat = "Use 'nameof({0})' instead of specifying the parameter name.";
-        internal const string Category = SupportedCategories.Design;
-        const string Description = "In C#6 the nameof() operator should be used to specify the name of a parameter instead of "
-            + "a string literal as it produce code that is easier to refactor.";
+        private const char DotChar = '.';
 
+        internal const string Title = "You should use nameof instead of program element name string";
+        internal const string MessageFormat = "Use 'nameof({0})' instead of specifying the program element name.";
+        internal const string Category = SupportedCategories.Design;
+        const string Description = "In C#6 the nameof() operator should be used to specify the name of a program element instead of "
+            + "a string literal as it produce code that is easier to refactor.";
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId.NameOf.ToDiagnosticId(),
             Title,
             MessageFormat,
             Category,
             DiagnosticSeverity.Warning,
-            isEnabledByDefault: true,
+            isEnabledByDefault: false,
             description: Description,
             helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.NameOf));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context) =>
-            context.RegisterSyntaxNodeAction(LanguageVersion.CSharp6, Analyzer, SyntaxKind.StringLiteralExpression);
+            context.RegisterSyntaxNodeAction(LanguageVersion.CSharp6, Analyze, SyntaxKind.StringLiteralExpression);
 
-        private void Analyzer(SyntaxNodeAnalysisContext context)
+        private void Analyze(SyntaxNodeAnalysisContext context)
         {
             if (context.IsGenerated()) return;
             var stringLiteral = context.Node as LiteralExpressionSyntax;
             if (string.IsNullOrWhiteSpace(stringLiteral?.Token.ValueText)) return;
-            var parameters = GetParameters(stringLiteral);
-            if (!parameters.Any()) return;
-            var attribute = stringLiteral.FirstAncestorOfType<AttributeSyntax>();
-            var method = stringLiteral.FirstAncestorOfType(typeof(MethodDeclarationSyntax), typeof(ConstructorDeclarationSyntax)) as BaseMethodDeclarationSyntax;
-            if (attribute != null && method.AttributeLists.Any(a => a.Attributes.Contains(attribute))) return;
-            var parameter = GetParameterWithIdentifierEqualToStringLiteral(stringLiteral, parameters);
-            if (parameter == null) return;
-            var diagnostic = Diagnostic.Create(Rule, stringLiteral.GetLocation(), parameter.Identifier.Text);
-            context.ReportDiagnostic(diagnostic);
+
+            var programElementName = GetProgramElementNameThatMatchStringLiteral(stringLiteral, context.SemanticModel);
+
+            if (Found(programElementName))
+            {
+                var diagnostic = Diagnostic.Create(Rule, stringLiteral.GetLocation(), programElementName);
+                context.ReportDiagnostic(diagnostic);
+            }
         }
 
-        public SeparatedSyntaxList<ParameterSyntax> GetParameters(SyntaxNode node)
+        private static string GetProgramElementNameThatMatchStringLiteral(LiteralExpressionSyntax stringLiteral, SemanticModel semanticModel)
         {
-            var methodDeclaration = node.FirstAncestorOfType<MethodDeclarationSyntax>();
-            SeparatedSyntaxList<ParameterSyntax> parameters;
-            if (methodDeclaration != null)
+            var programElementName = GetParameterNameThatMatchStringLiteral(stringLiteral);
+
+            if (!Found(programElementName))
             {
-                parameters = methodDeclaration.ParameterList.Parameters;
+                var literalValueText = stringLiteral.Token.ValueText;
+                var symbol = semanticModel.LookupSymbols(stringLiteral.Token.SpanStart, null, literalValueText).FirstOrDefault();
+
+                programElementName = symbol?.ToDisplayParts().LastOrDefault(IncludeOnlyPartsThatAreName).ToString();
+
+                if(!Found(programElementName))
+                {
+                    symbol = GetNamespaceSymbolThatEqualsStringLiteral(stringLiteral, semanticModel);
+
+                    if(symbol != null)
+                    {
+                        programElementName = literalValueText;
+                    }
+                }
+            }
+
+            return programElementName;
+        }
+
+        private static ISymbol GetNamespaceSymbolThatEqualsStringLiteral(LiteralExpressionSyntax stringLiteral, SemanticModel semanticModel)
+        {
+            ISymbol result = null;
+            var valueText = stringLiteral.Token.ValueText;
+            if (valueText.IndexOf(DotChar) > 0)
+            {
+                var lastPartNamespaceStartIndex = valueText.LastIndexOf(DotChar);
+                if (lastPartNamespaceStartIndex + 1 <= valueText.Length)
+                {
+                    var lastPartNamespace = valueText.Substring(lastPartNamespaceStartIndex + 1);
+
+                    var namespaceSymbol = semanticModel.LookupNamespacesAndTypes(stringLiteral.Token.SpanStart, null, lastPartNamespace).FirstOrDefault();
+
+                    if(namespaceSymbol != null && IsStringLiteralProperPartOfNamespaceName(valueText, namespaceSymbol.ToDisplayString()))
+                    {
+                        result = namespaceSymbol;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static string GetParameterNameThatMatchStringLiteral(LiteralExpressionSyntax stringLiteral)
+        {
+            var ancestorThatMightHaveParameters = stringLiteral.FirstAncestorOfType(typeof(AttributeListSyntax), typeof(MethodDeclarationSyntax), typeof(ConstructorDeclarationSyntax), typeof(IndexerDeclarationSyntax));
+            var parameterName = string.Empty;
+            if (ancestorThatMightHaveParameters != null)
+            {
+                var parameters = new SeparatedSyntaxList<ParameterSyntax>();
+                switch (ancestorThatMightHaveParameters.Kind())
+                {
+                    case SyntaxKind.MethodDeclaration:
+                    case SyntaxKind.ConstructorDeclaration:
+                        {
+                            var method = (BaseMethodDeclarationSyntax)ancestorThatMightHaveParameters;
+                            parameters = method.ParameterList.Parameters;
+                            break;
+                        }
+                    case SyntaxKind.IndexerDeclaration:
+                        {
+                            var indexer = (IndexerDeclarationSyntax)ancestorThatMightHaveParameters;
+                            parameters = indexer.ParameterList.Parameters;
+                            break;
+                        }
+                    case SyntaxKind.AttributeList:
+                        {
+                            break;
+                        }
+                }
+
+                parameterName = GetParameterWithIdentifierEqualToStringLiteral(stringLiteral, parameters)?.Identifier.Text;
+            }
+
+            return parameterName;
+        }
+
+        private static bool IsStringLiteralProperPartOfNamespaceName(string stringLiteral, string namespaceName)
+        {
+            var result = false;
+
+            var lastOccurence = namespaceName.LastIndexOf(stringLiteral, StringComparison.Ordinal);
+            var areStringsSameLength = stringLiteral.Length == namespaceName.Length;
+
+            if (!areStringsSameLength || lastOccurence >= 0)
+            {
+                var previousCharEqualsDot = lastOccurence > 0 ? namespaceName[lastOccurence - 1].Equals(DotChar) : true;
+
+                var nextCharIndex = lastOccurence + stringLiteral.Length;
+                var nextCharIndexExists = nextCharIndex < namespaceName.Length;
+                var nextCharEqualsDot = nextCharIndexExists ? namespaceName[nextCharIndex].Equals(DotChar) : true;
+
+                result = previousCharEqualsDot || nextCharEqualsDot;
             }
             else
             {
-                var constructorDeclaration = node.FirstAncestorOfType<ConstructorDeclarationSyntax>();
-                if (constructorDeclaration != null)
-                    parameters = constructorDeclaration.ParameterList.Parameters;
-                else return new SeparatedSyntaxList<ParameterSyntax>();
+                result = lastOccurence >= 0;
             }
-            return parameters;
+
+            return result;
         }
 
-        private ParameterSyntax GetParameterWithIdentifierEqualToStringLiteral(LiteralExpressionSyntax stringLiteral, SeparatedSyntaxList<ParameterSyntax> parameters) =>
-            parameters.FirstOrDefault(m => m.Identifier.Value.ToString() == stringLiteral.Token.Value.ToString());
+        private static bool Found(string programElement) => !string.IsNullOrEmpty(programElement);
+
+        private static bool IncludeOnlyPartsThatAreName(SymbolDisplayPart displayPart) =>
+            displayPart.IsAnyKind(SymbolDisplayPartKind.ClassName, SymbolDisplayPartKind.DelegateName, SymbolDisplayPartKind.EnumName, SymbolDisplayPartKind.EventName, SymbolDisplayPartKind.FieldName, SymbolDisplayPartKind.InterfaceName, SymbolDisplayPartKind.LocalName, SymbolDisplayPartKind.MethodName, SymbolDisplayPartKind.NamespaceName, SymbolDisplayPartKind.ParameterName, SymbolDisplayPartKind.PropertyName, SymbolDisplayPartKind.StructName);
+
+        private static ParameterSyntax GetParameterWithIdentifierEqualToStringLiteral(LiteralExpressionSyntax stringLiteral, SeparatedSyntaxList<ParameterSyntax> parameters) =>
+            parameters.FirstOrDefault(m => string.Equals(m.Identifier.ValueText, stringLiteral.Token.ValueText, StringComparison.Ordinal));
     }
 }

--- a/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
+++ b/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
@@ -29,6 +29,15 @@ namespace CodeCracker
             return false;
         }
 
+        public static bool IsAnyKind(this SymbolDisplayPart displayPart, params SymbolDisplayPartKind[] kinds)
+        {
+            foreach (var kind in kinds)
+            {
+                if (displayPart.Kind == kind) return true;
+            }
+            return false;
+        }
+
         public static StatementSyntax FirstAncestorOrSelfThatIsAStatement(this SyntaxNode node)
         {
             var currentNode = node;

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -376,6 +376,11 @@ namespace N1.N2
                     return variable;
                 }
             }
+
+            public string verbatimString = @""
+verbatim
+string
+lines"";
         }
     }
 }";

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -7,33 +7,43 @@ namespace CodeCracker.Test.CSharp.Design
 {
     public class NameOfTests : CodeFixVerifier<NameOfAnalyzer, NameOfCodeFixProvider>
     {
-        [Fact]
-        public async Task IgnoreIfStringLiteralIsWhiteSpace()
+        [Theory]
+        [InlineData("","")]
+        [InlineData("", "null")]
+        [InlineData("", "b")]
+        [InlineData("string a", "b")]
+        public async Task WhenStringLiteralInMethodShouldNotReportDiagnostic(string parameters, string stringLiteral)
         {
-            const string test = @"
+            var source = @"
 public class TypeName
 {
-    void Foo()
+    void Foo(" + parameters + @")
     {
-        var whatever = """";
+        var whatever = """ + stringLiteral + @""";
     }
 }";
-            await VerifyCSharpHasNoDiagnosticsAsync(test);
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
 
-        [Fact]
-        public async Task IgnoreIfStringLiteralIsNull()
+        [Theory]
+        [InlineData("string b", "b", "b", "Test0.cs", 6, 24)]
+        [InlineData("string @for","for", "@for", "Test0.cs", 6, 24)]
+        [InlineData("string @xyz", "xyz", "@xyz", "Test0.cs", 6, 24)]
+        public async Task WhenStringLiteralInMethodShouldReportDiagnostic(string parameters, string stringLiteral, string nameofArgument, string diagnosticFilePath, int diagnosticLine, int diagnosticColumn)
         {
-            const string test = @"
+            var source = @"
 public class TypeName
 {
-    void Foo()
+    void Foo(" + parameters + @")
     {
-        var whatever = null;
+        var whatever = """ + stringLiteral + @""";
     }
 }";
 
-            await VerifyCSharpHasNoDiagnosticsAsync(test);
+            var expected = CreateNameofDiagnosticResult(nameofArgument, diagnosticLine, diagnosticColumn, diagnosticFilePath);
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
         }
 
         [Fact]
@@ -52,98 +62,332 @@ public class TypeName()
         }
 
         [Fact]
-        public async Task IgnoreIfMethodHasNoParameters()
+        public async Task WhenUsingSomeStringInAttributeShouldNotReportDiagnostic()
         {
             const string test = @"
 public class TypeName
 {
-    void Foo()
-    {
-        var whatever = ""b"";
-    }
-}";
-
-            await VerifyCSharpHasNoDiagnosticsAsync(test);
-        }
-
-        [Fact]
-        public async Task IgnoreIfMethodHasParametersUnlikeOfStringLiteral()
-        {
-            const string test = @"
-public class TypeName
-{
+    [Whatever(""a"")]
+    [Whatever(""xyz""]
     void Foo(string a)
     {
-        var whatever = ""b"";
     }
 }";
-
             await VerifyCSharpHasNoDiagnosticsAsync(test);
         }
 
-        [Fact]
-        public async Task WhenUsingStringLiteralEqualsParameterNameReturnAnalyzerCreatesDiagnostic()
+        [Theory]
+        [InlineData("xyz", false, "", 0 ,0)]
+        [InlineData("OtherProperty", true, "Test0.cs", 18, 18)]
+        [InlineData("SomeStruct", true, "Test0.cs", 18, 18)]
+        [InlineData("readonlyField", true, "Test0.cs", 18, 18)]
+        [InlineData("Property", true, "Test0.cs", 18, 18)]
+        public async Task WhenUsingProgramElementNameStringAsIndexerParameter(string stringLiteral, bool shouldReportDiagnostic, string diagnosticFilePath, int diagnosticLine, int diagnosticColumn)
         {
-            const string source = @"
+            var source = @"
 public class TypeName
 {
-    void Foo(string b)
+    private readonly int readonlyField;
+    public int OtherProperty { get; set; }
+    public event EventHandler ParticularEvent;
+    public delegate int SomeDelegate(int c, double d);
+
+    public interface IInterface {}
+    public struct SomeStruct {}
+    public enum SomeEnum {}
+    public class NestedClass {}
+
+    public int Property
     {
-        string whatever = ""b"";
+        set
+        {
+            this[""" + stringLiteral + @"""] = value;
+        }
+    }
+
+    public int this[string s]
+    {
+        get { return 0;}
+        set { }
     }
 }";
-            var expected = new DiagnosticResult
+            if (!shouldReportDiagnostic)
             {
-                Id = DiagnosticId.NameOf.ToDiagnosticId(),
-                Message = "Use 'nameof(b)' instead of specifying the parameter name.",
-                Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 27) }
+                await VerifyCSharpHasNoDiagnosticsAsync(source);
+            }
+            else
+            {
+                var expected = CreateNameofDiagnosticResult(stringLiteral, diagnosticLine, diagnosticColumn, diagnosticFilePath);
+
+                await VerifyCSharpDiagnosticAsync(source, expected);
+            }
+        }
+
+        [Theory]
+        [InlineData("xyz", false, "", 0, 0)]
+        [InlineData("NestedClass", true, "Test0.cs", 22, 35)]
+        [InlineData("SomeStruct", true, "Test0.cs", 22, 35)]
+        [InlineData("SomeEnum", true, "Test0.cs", 22, 35)]
+        [InlineData("IInterface", true, "Test0.cs", 22, 35)]
+        [InlineData("N2", true, "Test0.cs", 22, 35)]
+        [InlineData("SomeDelegate", true, "Test0.cs", 22, 35)]
+        [InlineData("readonlyField", true, "Test0.cs", 22, 35)]
+        [InlineData("ParticularEvent", true, "Test0.cs", 22, 35)]
+        [InlineData("Property", true, "Test0.cs", 22, 35)]
+        [InlineData("TypeName", true, "Test0.cs", 22, 35)]
+        [InlineData("Invoke", true, "Test0.cs", 22, 35)]
+        [InlineData("N1", true, "Test0.cs", 22, 35)]
+        [InlineData("N3", true, "Test0.cs", 22, 35)]
+        public async Task WhenUsingProgramElementNameStringInMethodInvocation(string stringLiteral, bool shouldReportDiagnostic, string diagnosticFilePath, int diagnosticLine, int diagnosticColumn)
+        {
+            var source = @"
+namespace N1.N2
+{
+    namespace N3
+    {
+        public class TypeName
+        {
+            private readonly int readonlyField;
+            public int Property { get; set; }
+            public event EventHandler ParticularEvent;
+            public delegate int SomeDelegate(int c, double d);
+
+            public interface IInterface {}
+            public struct SomeStruct {}
+            public enum SomeEnum {}
+            public class NestedClass {}
+
+            public int Property
+            {
+                set
+                {
+                    Invoke(""abc"", """ + stringLiteral + @""");
+                }
+            }
+
+            private void Invoke(string arg1, string arg2)
+            {
+            }
+        }
+    }
+}";
+            if (!shouldReportDiagnostic)
+            {
+                await VerifyCSharpHasNoDiagnosticsAsync(source);
+            }
+            else
+            {
+                var expected = CreateNameofDiagnosticResult(stringLiteral, diagnosticLine, diagnosticColumn, diagnosticFilePath);
+
+                await VerifyCSharpDiagnosticAsync(source, expected);
+            }
+        }
+
+        [Fact]
+        public async Task WhenUsingProgramElementStringInVariableAssignment()
+        {
+            const string source = @"
+public class TypeName
+{
+    private readonly int readonlyField;
+    public class NestedClass {}
+
+    public int Property
+    {
+        set
+        {
+            string variable = ""NestedClass"";
+            variable = ""xyz"";
+            variable = ""readonlyField"";
+        }
+    }
+}";
+
+            var expectedForFirstAssignment = CreateNameofDiagnosticResult("NestedClass", 11, 31);
+            var expectedForSecondAssignment = CreateNameofDiagnosticResult("readonlyField", 13, 24);
+
+            await VerifyCSharpDiagnosticAsync(source, expectedForFirstAssignment, expectedForSecondAssignment);
+        }
+
+        [Fact]
+        public async Task WhenUsingProgramElementNameStringInAttributeShouldReportDiagnostic()
+        {
+            const string source = @"
+namespace N1.N2
+{
+    public class TypeName
+    {
+        private readonly int readonlyField;
+        public int Property { get; set; }
+        public event EventHandler ParticularEvent;
+        public delegate int SomeDelegate(int c, double d);
+
+        [Whatever(""N2"")]
+        [Whatever(""SomeDelegate"")]
+        [Whatever(""readonlyField"")]
+        [Whatever(""ParticularEvent"")]
+        [Whatever(""Property"")]
+        [Whatever(""TypeName"")]
+        [Whatever(""Foo"")]
+        [Whatever(""N1"")]
+        void Foo(string a)
+        {
+        }
+    }
+}";
+            var expected = new[]
+            {
+                CreateNameofDiagnosticResult("N2", 11, 19),
+                CreateNameofDiagnosticResult("SomeDelegate", 12, 19),
+                CreateNameofDiagnosticResult("readonlyField", 13, 19),
+                CreateNameofDiagnosticResult("ParticularEvent", 14, 19),
+                CreateNameofDiagnosticResult("Property", 15, 19),
+                CreateNameofDiagnosticResult("TypeName", 16, 19),
+                CreateNameofDiagnosticResult("Foo", 17, 19),
+                CreateNameofDiagnosticResult("N1", 18, 19)
             };
 
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
 
         [Fact]
-        public async Task WhenUsingVerbatimSpecifierWithKeywordEqualsParameterNameReturnAnalyzerCreatesDiagnostic()
+        public async Task WhenUsingStringLiteralInObjectInitializer()
+        {
+            const string source = @"
+namespace N1.N2
+{
+    public class OtherTypeName
+    {
+        public string Property { get; set; }
+        private string Property2 { get; set; }
+        public string Property3 { get; set; }
+    }
+
+    public class TypeName
+    {
+   
+        void Foo(string a)
+        {
+            var instance = new OtherTypeName
+            {
+                Property = ""xyz"",
+                Property2 = ""OtherTypeName"",
+                Property3 = ""Property2""
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(source, CreateNameofDiagnosticResult("OtherTypeName", 19, 29));
+        }
+
+        [Fact]
+        public async Task WhenUsingProgramElementNameInArrayInitializer()
         {
             const string source = @"
 public class TypeName
 {
-    void Foo(string @for)
+    private readonly int readonlyField;
+    public interface IInterface {}
+    
+    void Foo(string a)
     {
-        string whatever = ""for"";
+        var tab = new[] { ""readonlyField"", ""xyz"", ""IInterface"" };
     }
-}
-";
-            var expected = new DiagnosticResult
+}";
+            var expected = new[]
             {
-                Id = DiagnosticId.NameOf.ToDiagnosticId(),
-                Message = "Use 'nameof(@for)' instead of specifying the parameter name.",
-                Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 27) }
+                CreateNameofDiagnosticResult("readonlyField", 9, 27),
+                CreateNameofDiagnosticResult("IInterface", 9, 51)
             };
 
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
 
         [Fact]
-        public async Task WhenUsingVerbatimSpecifierWithSimpleIdentifierEqualsParameterNameReturnAnalyzerCreatesDiagnostic()
+        public async Task WhenCreatingNewObjectWithStringLiterals()
         {
             const string source = @"
-public class TypeName
+public struct TypeName
 {
-    void Foo(string @xyz)
+   
+    void Foo(string a)
     {
-        string whatever = ""xyz"";
+        var instance = new OtherTypeName(""b"", ""xyz"");
+        instance2 = new OtherTypeName(""TypeName"", ""a"");
     }
-}
-";
-            var expected = new DiagnosticResult
+}";
+            var expected = new[]
             {
-                Id = DiagnosticId.NameOf.ToDiagnosticId(),
-                Message = "Use 'nameof(@xyz)' instead of specifying the parameter name.",
-                Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 27) }
+                CreateNameofDiagnosticResult("TypeName", 8, 39),
+                CreateNameofDiagnosticResult("a", 8, 51)
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task WhenUsingStringLiteralInVariousPlaces()
+        {
+            const string source = @"
+namespace N1.N2
+{
+    namespace @using
+    {
+        public delegate int SomeDelegate(int a, int b);
+
+        public class BaseTypeName
+        {
+            public BaseTypeName(string a)
+            {
+            }
+        }
+
+        public class @class : BaseTypeName
+        {
+            private readonly int readonlyField;
+            public event EventHandler ParticularEvent;
+
+            public string className = ""class"";
+            public string fieldName = ""field"";
+            public string someName = ""variable"";
+            public string namespaceName = ""using"";
+            public string namespaceName2 = ""N2"";
+    
+            void Foo() => string.Format(""{0}"", ""xyz"");
+            void Foo2() => string.Format(""{0}"", ""readonlyField"");
+
+            public @class() : base(""SomeDelegate"") { }
+
+            void Foo3(string a)
+            {
+                Dictionary<string, string> dict = new Dictionary<string, string>
+                {
+                    { ""b"", ""readonlyField"" },
+                    { ""xyz"", ""ParticularEvent"" }
+                };
+            }
+
+            public int Property
+            {
+                get
+                {
+                    var variable = 5;
+                    return variable;
+                }
+            }
+        }
+    }
+}";
+            var expected = new[]
+            {
+                CreateNameofDiagnosticResult("@class", 20, 39),
+                CreateNameofDiagnosticResult("@using", 23, 43),
+                CreateNameofDiagnosticResult("N2", 24, 44),
+                CreateNameofDiagnosticResult("readonlyField", 27, 49),
+                CreateNameofDiagnosticResult("SomeDelegate", 29, 36),
+                CreateNameofDiagnosticResult("readonlyField", 35, 28),
+                CreateNameofDiagnosticResult("ParticularEvent", 36, 30)
             };
 
             await VerifyCSharpDiagnosticAsync(source, expected);
@@ -343,18 +587,15 @@ public class TypeName
             await VerifyCSharpFixAllAsync(source, fixtest);
         }
 
-        [Fact]
-        public async Task IgnoreAttributes()
+        private static DiagnosticResult CreateNameofDiagnosticResult(string nameofArgument, int diagnosticLine, int diagnosticColumn, string diagnosticFilePath = "Test0.cs")
         {
-            const string test = @"
-public class TypeName
-{
-    [Whatever(""a"")]
-    void Foo(string a)
-    {
-    }
-}";
-            await VerifyCSharpHasNoDiagnosticsAsync(test);
+            return new DiagnosticResult
+            {
+                Id = DiagnosticId.NameOf.ToDiagnosticId(),
+                Message = string.Format("Use 'nameof({0})' instead of specifying the program element name.", nameofArgument),
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation(diagnosticFilePath, diagnosticLine, diagnosticColumn) }
+            };
         }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -377,6 +377,8 @@ namespace N1.N2
                 }
             }
 
+            public string namespaceName3 = ""N1.N2"";
+
             public string verbatimString = @""
 verbatim
 string


### PR DESCRIPTION
Fixes C# part of #263 

Changed C# NameOfAnalyzer to work with any scope.
Now NameOfAnalyzer first check if string literal is in method/constructor/indexer and tries to find match in parameters list.
If that fails semantic model is used to lookup symbols/namespaces.