### PR TITLE
Missing parameter when installing through Nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ changes to source control and share with your team, then you also want the Nuget
 To install from Nuget, for the C# version:
 
 ```powershell
-Install-Package CodeCracker.CSharp
+Install-Package CodeCracker.CSharp -Pre
 ```
 
 Or for the Visual Basic version:
 
 ```powershell
-Install-Package CodeCracker.VisualBasic
+Install-Package CodeCracker.VisualBasic -Pre
 ```
 
 Or use the Package Manager in Visual Studio.


### PR DESCRIPTION
Added -Pre parameter to Install-Package. 

Missing this parameter will get an exception.
```
At line:1 char:1
+ install-package CodeCracker.CSharp
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Install-Package], Exception
    + FullyQualifiedErrorId : NuGetCmdletUnhandledException,NuGet.PackageManagement.PowerShellCmdlets.InstallPackageCommand
 ```