### PR TITLE
Update RemovePrivateMethodNeverUsed to work with generic methods

### DIFF
--- a/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
@@ -48,24 +48,24 @@ namespace CodeCracker.CSharp.Usage
             var typeDeclaration = methodTarget.Parent as TypeDeclarationSyntax;
             if (typeDeclaration == null) return true;
 
-	        if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
-		        return IsMethodUsed(methodTarget, typeDeclaration);
+            if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+                return IsMethodUsed(methodTarget, typeDeclaration);
 
-	        var symbol = semanticModel.GetDeclaredSymbol(typeDeclaration);
+            var symbol = semanticModel.GetDeclaredSymbol(typeDeclaration);
 
-			return
-				symbol == null ||
-				symbol.DeclaringSyntaxReferences.Any(reference => IsMethodUsed(methodTarget, reference.GetSyntax()));
+            return
+                symbol == null ||
+                symbol.DeclaringSyntaxReferences.Any(reference => IsMethodUsed(methodTarget, reference.GetSyntax()));
         }
 
-		private static bool IsMethodUsed(MethodDeclarationSyntax methodTarget, SyntaxNode typeDeclaration)
-		{
+        private static bool IsMethodUsed(MethodDeclarationSyntax methodTarget, SyntaxNode typeDeclaration)
+        {
             var descendents = typeDeclaration.DescendantNodes();
-			var hasIdentifier = descendents.OfType<IdentifierNameSyntax>();
+            var hasIdentifier = descendents.OfType<IdentifierNameSyntax>();
             if (hasIdentifier.Any(a => a != null && a.Identifier.ValueText.Equals(methodTarget.Identifier.ValueText)))
                 return true;
-			var genericNames = descendents.OfType<GenericNameSyntax>();
+            var genericNames = descendents.OfType<GenericNameSyntax>();
             return genericNames.Any(n => n != null && n.Identifier.ValueText.Equals(methodTarget.Identifier.ValueText));
-		}
-	}
+        }
+    }
 }

--- a/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
@@ -26,10 +26,10 @@ namespace CodeCracker.Test.CSharp.Usage
             await VerifyCSharpHasNoDiagnosticsAsync(test);
         }
 
-		[Fact]
-		public async void DoesNotGenerateDiagnosticsWhenPrivateMethodIsInvokedInPartialClasses()
-		{
-			const string test = @"
+        [Fact]
+        public async void DoesNotGenerateDiagnosticsWhenPrivateMethodIsInvokedInPartialClasses()
+        {
+            const string test = @"
 public partial class Foo
 {
     public void PublicFoo()
@@ -46,14 +46,14 @@ public partial class Foo
 }
 ";
 
-			await VerifyCSharpHasNoDiagnosticsAsync(test);
-		}
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
 
 
-		[Fact]
-		public async void DoesNotGenerateDiagnosticsWhenPrivateMethodIsInvokedInPartialClasses2()
-		{
-			const string test = @"
+        [Fact]
+        public async void DoesNotGenerateDiagnosticsWhenPrivateMethodIsInvokedInPartialClasses2()
+        {
+            const string test = @"
 public partial class foo
 {
     public foo()
@@ -73,14 +73,14 @@ public partial class foo
         test();
     }
 }";
-			await VerifyCSharpHasNoDiagnosticsAsync(test);
-		}
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
 
 
-		[Fact]
-		public async void FixRemovesPrivateMethodWhenItIsNotInvokedInPartialClasses()
-		{
-			const string test = @"
+        [Fact]
+        public async void FixRemovesPrivateMethodWhenItIsNotInvokedInPartialClasses()
+        {
+            const string test = @"
 public partial class Foo
 {
     public void PublicFoo()
@@ -96,7 +96,7 @@ public partial class Foo
 }
 ";
 
-			const string expected = @"
+            const string expected = @"
 public partial class Foo
 {
     public void PublicFoo()
@@ -109,10 +109,10 @@ public partial class Foo
 }
 ";
 
-			await VerifyCSharpFixAsync(test, expected);
-		}
+            await VerifyCSharpFixAsync(test, expected);
+        }
 
-		[Fact]
+        [Fact]
         public async void WhenPrivateMethodUsedDoesNotGenerateDiagnostics()
         {
             const string test = @"
@@ -160,6 +160,72 @@ class Foo
 }";
             await VerifyCSharpFixAsync(source, fixtest);
 
+        }
+
+        [Fact]
+        public async void GenericMethodDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    void PrivateFoo<T>() { }
+    public void Go()
+    {
+        PrivateFoo<int>();
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void GenericMethodWithConstraintDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    void PrivateFoo<T>() where T : Foo { }
+    public void Go()
+    {
+        PrivateFoo<Foo>();
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void StaticMethodDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static void PrivateFoo() { }
+    public void Go()
+    {
+        PrivateFoo();
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void PrivateGenericStaticWithConstraintDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    private static SymbolAnalysisContext GetSymbolAnalysisContext<T>(string code, string fileName = ""a.cs"") where T : SyntaxNode
+    {
+    }
+    public void Go()
+    {
+        GetSymbolAnalysisContext<ClassDeclarationSyntax>(""class TypeName { }"", ""TemporaryGeneratedFile_.cs"");
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
     }
 }


### PR DESCRIPTION
The first commit is better to analyze the PR. The 2nd one is to update from tabs to spaces, the file was incorrectly formatted.
Closes #343.