### PR TITLE
CS0050 code fix

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInfo.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInMethodParameter.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInfoProvider.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInMethodReturnType.cs" />
     <Compile Include="Extensions\CSharpAnalyzerExtensions.cs" />
     <Compile Include="Performance\UseStaticRegexIsMatchAnalyzer.cs" />
     <Compile Include="Performance\StringBuilderInLoopCodeFixProvider.cs" />

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
@@ -22,6 +22,7 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber, InconsistentAccessibilityInMethodParameterCompilerErrorNumber);
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -51,6 +52,9 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 
             switch (diagnostic.Id)
             {
+                case InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber:
+                    inconsistentAccessibilityProvider = new InconsistentAccessibilityInMethodReturnType();
+                    break;
                 case InconsistentAccessibilityInMethodParameterCompilerErrorNumber:
                     inconsistentAccessibilityProvider = new InconsistentAccessibilityInMethodParameter();
                     break;

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodParameter.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodParameter.cs
@@ -14,7 +14,7 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 {
     public sealed class InconsistentAccessibilityInMethodParameter : InconsistentAccessibilityInfoProvider
     {
-        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInMethodParameter_CodeActionMessage), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInMethodParameter_Title), Resources.ResourceManager, typeof(Resources));
 
         public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodReturnType.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodReturnType.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class InconsistentAccessibilityInMethodReturnType : InconsistentAccessibilityInfoProvider
+    {
+        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInMethodReturnType_CodeActionMessage), Resources.ResourceManager, typeof(Resources));
+
+        public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var result = new InconsistentAccessibilityInfo();
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var methodThatRaisedError = syntaxRoot.FindNode(diagnostic.Location.SourceSpan).DescendantNodesAndSelf().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+            if (methodThatRaisedError != null)
+            {
+                result.TypeToChangeAccessibility = methodThatRaisedError.ReturnType;
+                result.CodeActionMessage = string.Format(CodeActionMessage.ToString(), methodThatRaisedError.ReturnType, methodThatRaisedError.GetIdentifier().ValueText);
+                result.NewAccessibilityModifiers = methodThatRaisedError.CloneAccessibilityModifiers();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodReturnType.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodReturnType.cs
@@ -14,7 +14,7 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 {
     public sealed class InconsistentAccessibilityInMethodReturnType : InconsistentAccessibilityInfoProvider
     {
-        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInMethodReturnType_CodeActionMessage), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInMethodReturnType_Title), Resources.ResourceManager, typeof(Resources));
 
         public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {

--- a/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
+++ b/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
@@ -209,6 +209,26 @@ namespace CodeCracker
             );
         }
 
+        public static SyntaxToken GetIdentifier(this BaseMethodDeclarationSyntax method)
+        {
+            var result = default(SyntaxToken);
+
+            switch(method.Kind())
+            {
+                case SyntaxKind.MethodDeclaration:
+                    result = ((MethodDeclarationSyntax)method).Identifier;
+                    break;
+                case SyntaxKind.ConstructorDeclaration:
+                    result = ((ConstructorDeclarationSyntax)method).Identifier;
+                    break;
+                case SyntaxKind.DestructorDeclaration:
+                    result = ((DestructorDeclarationSyntax)method).Identifier;
+                    break;
+            }
+
+            return result;
+        }
+
         public static MemberDeclarationSyntax WithModifiers(this MemberDeclarationSyntax declaration, SyntaxTokenList newModifiers)
         {
             var result = declaration;
@@ -300,5 +320,20 @@ namespace CodeCracker
 
             return result;
         }
+
+        public static SyntaxTokenList CloneAccessibilityModifiers(this BaseMethodDeclarationSyntax method)
+        {
+            var modifiers = method.Modifiers;
+            if (method.Parent.IsKind(SyntaxKind.InterfaceDeclaration))
+            {
+                modifiers = ((InterfaceDeclarationSyntax)method.Parent).Modifiers;
+            }
+
+            var accessibilityModifiers = modifiers.Where(token => token.IsKind(SyntaxKind.PublicKeyword) || token.IsKind(SyntaxKind.ProtectedKeyword) || token.IsKind(SyntaxKind.InternalKeyword) || token.IsKind(SyntaxKind.PrivateKeyword)).Select(token => SyntaxFactory.Token(token.Kind()));
+
+            return SyntaxFactory.TokenList(EnsureProtectedBeforeInternal(accessibilityModifiers));
+        }
+
+        private static IEnumerable<SyntaxToken> EnsureProtectedBeforeInternal(IEnumerable<SyntaxToken> modifiers) => modifiers.OrderByDescending(token => token.RawKind);
     }
 }

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -64,18 +64,18 @@ namespace CodeCracker.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Change parameter type &apos;{0}&apos; accessibility to be as accessible as method &apos;{1}&apos;.
         /// </summary>
-        public static string InconsistentAccessibilityInMethodParameter_CodeActionMessage {
+        public static string InconsistentAccessibilityInMethodParameter_Title {
             get {
-                return ResourceManager.GetString("InconsistentAccessibilityInMethodParameter_CodeActionMessage", resourceCulture);
+                return ResourceManager.GetString("InconsistentAccessibilityInMethodParameter_Title", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Change return type &apos;{0}&apos; accessibility to be as accessible as method &apos;{1}&apos;.
         /// </summary>
-        public static string InconsistentAccessibilityInMethodReturnType_CodeActionMessage {
+        public static string InconsistentAccessibilityInMethodReturnType_Title {
             get {
-                return ResourceManager.GetString("InconsistentAccessibilityInMethodReturnType_CodeActionMessage", resourceCulture);
+                return ResourceManager.GetString("InconsistentAccessibilityInMethodReturnType_Title", resourceCulture);
             }
         }
         

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -62,6 +62,24 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change parameter type &apos;{0}&apos; accessibility to be as accessible as method &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInMethodParameter_CodeActionMessage {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInMethodParameter_CodeActionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change return type &apos;{0}&apos; accessibility to be as accessible as method &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInMethodReturnType_CodeActionMessage {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInMethodReturnType_CodeActionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In C#6 the nameof() operator should be used to specify the name of a program element instead of a string literal as it produce code that is easier to refactor..
         /// </summary>
         public static string NameOfAnalyzer_Description {

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InconsistentAccessibilityInMethodParameter_CodeActionMessage" xml:space="preserve">
+    <value>Change parameter type '{0}' accessibility to be as accessible as method '{1}'</value>
+  </data>
+  <data name="InconsistentAccessibilityInMethodReturnType_CodeActionMessage" xml:space="preserve">
+    <value>Change return type '{0}' accessibility to be as accessible as method '{1}'</value>
+  </data>
   <data name="NameOfAnalyzer_Description" xml:space="preserve">
     <value>In C#6 the nameof() operator should be used to specify the name of a program element instead of a string literal as it produce code that is easier to refactor.</value>
   </data>

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="InconsistentAccessibilityInMethodParameter_CodeActionMessage" xml:space="preserve">
+  <data name="InconsistentAccessibilityInMethodParameter_Title" xml:space="preserve">
     <value>Change parameter type '{0}' accessibility to be as accessible as method '{1}'</value>
   </data>
-  <data name="InconsistentAccessibilityInMethodReturnType_CodeActionMessage" xml:space="preserve">
+  <data name="InconsistentAccessibilityInMethodReturnType_Title" xml:space="preserve">
     <value>Change return type '{0}' accessibility to be as accessible as method '{1}'</value>
   </data>
   <data name="NameOfAnalyzer_Description" xml:space="preserve">

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -135,7 +135,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChangeCultureTests.cs" />
-    <Compile Include="Design\InconsistentAccessibilityTests.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.MethodParameter.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.MethodReturnType.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensionsTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Performance\UseStaticRegexIsMatchTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.MethodParameter.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.MethodParameter.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace CodeCracker.Test.CSharp.Design
 {
-    public class InconsistentAccessibilityTests : CodeFixVerifier
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
     {
         [Theory]
         [InlineData("class","internal")]

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.MethodReturnType.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.MethodReturnType.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ShouldFixInconsistentAccessibilityErrorInMethodReturnTypeAsync()
+        {
+            var testCode = @"public class Dependent
+{
+    public DependedUpon Method()
+    {
+        return null;
+    }
+}
+
+    internal class DependedUpon
+    {
+    }";
+            var fixedCode = @"public class Dependent
+{
+    public DependedUpon Method()
+    {
+        return null;
+    }
+}
+
+    public class DependedUpon
+    {
+    }";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixInconsistentAccessibilityErrorInMethodReturnTypeWhenQualifiedNameAsync()
+        {
+            var testCode = @"public class Dependent
+{
+    public Dependent.DependedUpon Method()
+    {
+        return null;
+    }
+
+    internal class DependedUpon
+    {
+    }
+}";
+            var fixedCode = @"public class Dependent
+{
+    public Dependent.DependedUpon Method()
+    {
+        return null;
+    }
+
+    public class DependedUpon
+    {
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
Fixes `CS0050` in #381 

I added `CS0050` to `InconsistentAccessibilityCodeFixProvider` with unit tests.
Also changed code action messages to use localizable strings.
Common methods used by `InconsistentAccessibilityInMethodParameter/(ReturnType)` were moved as extension methods.