### PR TITLE
Add string interpolation to Console.WriteLine

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Refactoring\ParameterRefactoryCodeFixProvider.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseAnalyzer.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseCodeFixProvider.cs" />
+    <Compile Include="Style\ConsoleWriteLineAnalyzer.cs" />
+    <Compile Include="Style\ConsoleWriteLineCodeFixProvider.cs" />
     <Compile Include="Style\UseEmptyStringAnalyzer.cs" />
     <Compile Include="Style\UseEmptyStringCodeFixProvider.cs" />
     <Compile Include="Style\UseEmptyStringCodeFixProviderAll.cs" />

--- a/src/CSharp/CodeCracker/Style/ConsoleWriteLineAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ConsoleWriteLineAnalyzer.cs
@@ -1,0 +1,34 @@
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace CodeCracker.CSharp.Style
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ConsoleWriteLineAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string Category = SupportedCategories.Style;
+        internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ConsoleWriteLineAnalyzer_Title), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.ConsoleWriteLineAnalyzer_MessageFormat), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ConsoleWriteLineAnalyzer_Description), Resources.ResourceManager, typeof(Resources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId.ConsoleWriteLine.ToDiagnosticId(),
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.ConsoleWriteLine));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeWriteLineInvocation, SyntaxKind.InvocationExpression);
+
+        private static void AnalyzeWriteLineInvocation(SyntaxNodeAnalysisContext context) =>
+            StringFormatAnalyzer.AnalyzeFormatInvocation(context, "WriteLine", "System.Console.WriteLine(string, object", "System.Console.WriteLine(string, params object[])", Rule);
+    }
+}

--- a/src/CSharp/CodeCracker/Style/ConsoleWriteLineCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/ConsoleWriteLineCodeFixProvider.cs
@@ -1,0 +1,41 @@
+﻿using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodeCracker.CSharp.Style
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ConsoleWriteLineCodeFixProvider)), Shared]
+    public class ConsoleWriteLineCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticId.ConsoleWriteLine.ToDiagnosticId());
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            context.RegisterCodeFix(CodeAction.Create(Resources.ConsoleWriteLineCodeFixProvider_Title, c => MakeStringInterpolationAsync(context.Document, diagnostic, c)), diagnostic);
+            return Task.FromResult(0);
+        }
+
+        private async static Task<Document> MakeStringInterpolationAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var invocationExpression = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
+            var newStringInterpolation = await StringFormatCodeFixProvider.CreateNewStringInterpolationAsync(document, root, invocationExpression, cancellationToken);
+            var newArgumentList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList<ArgumentSyntax>().Add(SyntaxFactory.Argument(newStringInterpolation)));
+            var newRoot = root.ReplaceNode(invocationExpression.ArgumentList, newArgumentList);
+            var newDocument = document.WithSyntaxRoot(newRoot);
+            return newDocument;
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Style/StringFormatAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/StringFormatAnalyzer.cs
@@ -1,3 +1,4 @@
+using CodeCracker.Properties;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,10 +12,10 @@ namespace CodeCracker.CSharp.Style
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class StringFormatAnalyzer : DiagnosticAnalyzer
     {
-        internal const string Title = "Use string interpolation instead of String.Format";
-        internal const string MessageFormat = "Use string interpolation";
         internal const string Category = SupportedCategories.Style;
-        const string Description = "String interpolation allows for better reading of the resulting string when compared to String.Format. You should use String.Format only when another method is supplying the format string.";
+        internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.StringFormatAnalyzer_Title), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.StringFormatAnalyzer_MessageFormat), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.StringFormatAnalyzer_Description), Resources.ResourceManager, typeof(Resources));
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId.StringFormat.ToDiagnosticId(),
@@ -28,21 +29,24 @@ namespace CodeCracker.CSharp.Style
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.InvocationExpression);
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeFormatInvocation, SyntaxKind.InvocationExpression);
 
-        private static void Analyzer(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeFormatInvocation(SyntaxNodeAnalysisContext context) =>
+            AnalyzeFormatInvocation(context, "Format", "string.Format(string, ", "string.Format(string, params object[])", Rule);
+
+        public static void AnalyzeFormatInvocation(SyntaxNodeAnalysisContext context, string methodName, string methodOverloadSignature, string methodWithArraySignature, DiagnosticDescriptor rule)
         {
             if (context.IsGenerated()) return;
             var invocationExpression = (InvocationExpressionSyntax)context.Node;
             var memberExpresion = invocationExpression.Expression as MemberAccessExpressionSyntax;
-            if (memberExpresion?.Name?.ToString() != "Format") return;
+            if (memberExpresion?.Name?.ToString() != methodName) return;
             var memberSymbol = context.SemanticModel.GetSymbolInfo(memberExpresion).Symbol;
             if (memberSymbol == null) return;
-            if (!memberSymbol.ToString().StartsWith("string.Format(string, ")) return;
+            if (!memberSymbol.ToString().StartsWith(methodOverloadSignature)) return;
             var argumentList = invocationExpression.ArgumentList as ArgumentListSyntax;
             if (argumentList?.Arguments.Count < 2) return;
             if (!argumentList.Arguments[0]?.Expression?.IsKind(SyntaxKind.StringLiteralExpression) ?? false) return;
-            if (memberSymbol.ToString() == "string.Format(string, params object[])" && argumentList.Arguments.Skip(1).Any(a => context.SemanticModel.GetTypeInfo(a.Expression).Type.TypeKind == TypeKind.Array)) return;
+            if (memberSymbol.ToString() == methodWithArraySignature && argumentList.Arguments.Skip(1).Any(a => context.SemanticModel.GetTypeInfo(a.Expression).Type.TypeKind == TypeKind.Array)) return;
             var formatLiteral = (LiteralExpressionSyntax)argumentList.Arguments[0].Expression;
             var format = (string)context.SemanticModel.GetConstantValue(formatLiteral).Value;
             var formatArgs = Enumerable.Range(1, argumentList.Arguments.Count - 1).Select(i => new object()).ToArray();
@@ -54,7 +58,7 @@ namespace CodeCracker.CSharp.Style
             {
                 return;
             }
-            var diag = Diagnostic.Create(Rule, invocationExpression.GetLocation());
+            var diag = Diagnostic.Create(rule, invocationExpression.GetLocation());
             context.ReportDiagnostic(diag);
         }
     }

--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -75,5 +75,6 @@
         RemoveRedundantElseClause = 89,
         MakeMethodStatic = 91,
         ChangeAllToAny = 92,
+        ConsoleWriteLine = 95,
     }
 }

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -62,6 +62,42 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to String interpolation allows for better reading of the resulting string when compared to Console.WriteLine arguments. You should use Console.WriteLine with arguments only when another method is supplying the format string..
+        /// </summary>
+        public static string ConsoleWriteLineAnalyzer_Description {
+            get {
+                return ResourceManager.GetString("ConsoleWriteLineAnalyzer_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use string interpolation.
+        /// </summary>
+        public static string ConsoleWriteLineAnalyzer_MessageFormat {
+            get {
+                return ResourceManager.GetString("ConsoleWriteLineAnalyzer_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use string interpolation instead of arguments on Console.WriteLine.
+        /// </summary>
+        public static string ConsoleWriteLineAnalyzer_Title {
+            get {
+                return ResourceManager.GetString("ConsoleWriteLineAnalyzer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change to string interpolation.
+        /// </summary>
+        public static string ConsoleWriteLineCodeFixProvider_Title {
+            get {
+                return ResourceManager.GetString("ConsoleWriteLineCodeFixProvider_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change parameter type &apos;{0}&apos; accessibility to be as accessible as method &apos;{1}&apos;.
         /// </summary>
         public static string InconsistentAccessibilityInMethodParameter_Title {
@@ -112,6 +148,42 @@ namespace CodeCracker.Properties {
         public static string NameOfCodeFixProvider_Title {
             get {
                 return ResourceManager.GetString("NameOfCodeFixProvider_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to String interpolation allows for better reading of the resulting string when compared to String.Format. You should use String.Format only when another method is supplying the format string..
+        /// </summary>
+        public static string StringFormatAnalyzer_Description {
+            get {
+                return ResourceManager.GetString("StringFormatAnalyzer_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use string interpolation.
+        /// </summary>
+        public static string StringFormatAnalyzer_MessageFormat {
+            get {
+                return ResourceManager.GetString("StringFormatAnalyzer_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use string interpolation instead of String.Format.
+        /// </summary>
+        public static string StringFormatAnalyzer_Title {
+            get {
+                return ResourceManager.GetString("StringFormatAnalyzer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change to string interpolation.
+        /// </summary>
+        public static string StringFormatCodeFixProvider_Title {
+            get {
+                return ResourceManager.GetString("StringFormatCodeFixProvider_Title", resourceCulture);
             }
         }
     }

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -123,6 +123,18 @@
   <data name="InconsistentAccessibilityInMethodReturnType_Title" xml:space="preserve">
     <value>Change return type '{0}' accessibility to be as accessible as method '{1}'</value>
   </data>
+  <data name="ConsoleWriteLineAnalyzer_Description" xml:space="preserve">
+    <value>String interpolation allows for better reading of the resulting string when compared to Console.WriteLine arguments. You should use Console.WriteLine with arguments only when another method is supplying the format string.</value>
+  </data>
+  <data name="ConsoleWriteLineAnalyzer_MessageFormat" xml:space="preserve">
+    <value>Use string interpolation</value>
+  </data>
+  <data name="ConsoleWriteLineAnalyzer_Title" xml:space="preserve">
+    <value>Use string interpolation instead of arguments on Console.WriteLine</value>
+  </data>
+  <data name="ConsoleWriteLineCodeFixProvider_Title" xml:space="preserve">
+    <value>Change to string interpolation</value>
+  </data>
   <data name="NameOfAnalyzer_Description" xml:space="preserve">
     <value>In C#6 the nameof() operator should be used to specify the name of a program element instead of a string literal as it produce code that is easier to refactor.</value>
   </data>
@@ -134,5 +146,17 @@
   </data>
   <data name="NameOfCodeFixProvider_Title" xml:space="preserve">
     <value>Use nameof()</value>
+  </data>
+  <data name="StringFormatAnalyzer_Description" xml:space="preserve">
+    <value>String interpolation allows for better reading of the resulting string when compared to String.Format. You should use String.Format only when another method is supplying the format string.</value>
+  </data>
+  <data name="StringFormatAnalyzer_MessageFormat" xml:space="preserve">
+    <value>Use string interpolation</value>
+  </data>
+  <data name="StringFormatAnalyzer_Title" xml:space="preserve">
+    <value>Use string interpolation instead of String.Format</value>
+  </data>
+  <data name="StringFormatCodeFixProvider_Title" xml:space="preserve">
+    <value>Change to string interpolation</value>
   </data>
 </root>

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Refactoring\ParameterRefectoryTests.cs" />
     <Compile Include="Refactoring\AllowMembersOrderingCodeFixProviderTests.StyleCop.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseTests.cs" />
+    <Compile Include="Style\ConsoleWriteLineTests.cs" />
     <Compile Include="Style\UseEmptyStringTest.cs" />
     <Compile Include="Style\UseStringEmptyTests.cs" />
     <Compile Include="Style\PropertyPrivateSetTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Style/ConsoleWriteLineTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ConsoleWriteLineTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace CodeCracker.Test.CSharp.Style
 {
-    public class StringFormatTests : CodeFixVerifier<StringFormatAnalyzer, StringFormatCodeFixProvider>
+    public class ConsoleWriteLineTests : CodeFixVerifier<ConsoleWriteLineAnalyzer, ConsoleWriteLineCodeFixProvider>
     {
         [Fact]
         public async Task IgnoresRegularStrings()
@@ -26,7 +26,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task IgnoresStringMethodsThatAreNotStringFormat()
+        public async Task IgnoresConsoleMethodsThatAreNotConsoleWriteLine()
         {
             const string source = @"
     using System;
@@ -36,7 +36,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var result = string.Compare(""a"", ""b"");
+                Console.Write(1);
             }
         }
     }";
@@ -44,18 +44,18 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task IgnoresMethodsCalledFormatThatAreNotStringFormat()
+        public async Task IgnoresMethodsCalledWriteLineThatAreNotConsoleWriteLine()
         {
             const string source = @"
     using System;
     namespace ConsoleApplication1
     {
-        class OtherString { public static string Format(string a, string b) { throw new NotImplementedException(); } }
+        class OtherString { public static string WriteLine(string a, string b) { throw new NotImplementedException(); } }
         class TypeName
         {
             void Foo()
             {
-                var result = OtherString.Format(""a"", ""b"");
+                var result = OtherString.WriteLine(""a"", ""b"");
             }
         }
     }";
@@ -63,7 +63,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task IgnoresStringFormatWithArrayArgWith1Object()
+        public async Task IgnoresConsoleWriteLineWithArrayArgWith1Object()
         {
             const string source = @"
     using System;
@@ -75,7 +75,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var args = new object[] { noun };
-                var s = string.Format(""This {0} is nice."", args);
+                Console.WriteLine(""This {0} is nice."", args);
             }
         }
     }";
@@ -83,7 +83,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task IgnoresStringFormatWithArrayArgWith2Objects()
+        public async Task IgnoresConsoleWriteLineWithArrayArgWith2Objects()
         {
             const string source = @"
     using System;
@@ -96,7 +96,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 var args = new object[] { noun, adjective };
-                var s = string.Format(""This {0} is {1}"", args);
+                Console.WriteLine(""This {0} is {1}"", args);
             }
         }
     }";
@@ -114,7 +114,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var result = string.Format(""a"");
+                Console.WriteLine(""a"");
             }
         }
     }";
@@ -132,7 +132,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var result = string.Format(1, ""b"");
+                Console.WriteLine(1, ""b"");
             }
         }
     }";
@@ -150,7 +150,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var result = string.Format(""one {0} two {1}"", ""a"");
+                Console.WriteLine(""one {0} two {1}"", ""a"");
             }
         }
     }";
@@ -158,7 +158,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task StringFormatWithMoreThan2ArgsProducesDiagnostic()
+        public async Task ConsoleWriteLineWithMoreThan2ArgsProducesDiagnostic()
         {
             const string source = @"
     using System;
@@ -170,22 +170,22 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(""This {0} is {1}"", noun, adjective);
+                Console.WriteLine(""This {0} is {1}"", noun, adjective);
             }
         }
     }";
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormat.ToDiagnosticId(),
-                Message = StringFormatAnalyzer.MessageFormat.ToString(),
+                Id = DiagnosticId.ConsoleWriteLine.ToDiagnosticId(),
+                Message = ConsoleWriteLineAnalyzer.MessageFormat.ToString(),
                 Severity = DiagnosticSeverity.Info,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 25) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 17) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
 
         [Fact]
-        public async Task StringFormatWithFullStringNameProducesDiagnostic()
+        public async Task ConsoleWriteLineWithFullStringNameProducesDiagnostic()
         {
             const string source = @"
     namespace ConsoleApplication1
@@ -196,22 +196,22 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = System.String.Format(""This {0} is {1}"", noun, adjective);
+                System.Console.WriteLine(""This {0} is {1}"", noun, adjective);
             }
         }
     }";
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormat.ToDiagnosticId(),
-                Message = StringFormatAnalyzer.MessageFormat.ToString(),
+                Id = DiagnosticId.ConsoleWriteLine.ToDiagnosticId(),
+                Message = ConsoleWriteLineAnalyzer.MessageFormat.ToString(),
                 Severity = DiagnosticSeverity.Info,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 25) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
 
         [Fact]
-        public async Task StringFormatChangesToStringInterpolation()
+        public async Task ConsoleWriteLineChangesToStringInterpolation()
         {
             const string source = @"
     using System;
@@ -224,7 +224,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 //comment before
-                var s = string.Format(""This {0} is {1}"", noun, adjective);//comment right after
+                Console.WriteLine(""This {0} is {1}"", noun, adjective);//comment right after
                 //comment after
             }
         }
@@ -240,7 +240,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 //comment before
-                var s = $""This {noun} is {adjective}"";//comment right after
+                Console.WriteLine($""This {noun} is {adjective}"");//comment right after
                 //comment after
             }
         }
@@ -249,7 +249,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task WhenStringFormatHasMoreArgumentsThanNecessaryChangesToStringInterpolationAndIgnoresExtraArgument()
+        public async Task WhenConsoleWriteLineHasMoreArgumentsThanNecessaryChangesToStringInterpolationAndIgnoresExtraArgument()
         {
             const string source = @"
     using System;
@@ -262,7 +262,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 var otherAdjective = ""loves c#"";
-                var s = string.Format(""This {0} is {1}"", noun, adjective, otherAdjective);
+                Console.WriteLine(""This {0} is {1}"", noun, adjective, otherAdjective);
             }
         }
     }";
@@ -277,7 +277,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 var otherAdjective = ""loves c#"";
-                var s = $""This {noun} is {adjective}"";
+                Console.WriteLine($""This {noun} is {adjective}"");
             }
         }
     }";
@@ -285,7 +285,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task WhenStringFormatHasEscapingItChangesToStringInterpolationAndRemovesEscapingSequence()
+        public async Task WhenConsoleWriteLineHasEscapingItChangesToStringInterpolationAndRemovesEscapingSequence()
         {
             const string source = @"
     using System;
@@ -297,7 +297,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(""This {{0}} {0} is {1}"", noun, adjective);
+                Console.WriteLine(""This {{0}} {0} is {1}"", noun, adjective);
             }
         }
     }";
@@ -311,7 +311,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = $""This {{0}} {noun} is {adjective}"";
+                Console.WriteLine($""This {{0}} {noun} is {adjective}"");
             }
         }
     }";
@@ -331,7 +331,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(""This {0} is\n \r\f \f \r {1}"", noun, adjective);
+                Console.WriteLine(""This {0} is\n \r\f \f \r {1}"", noun, adjective);
             }
         }
     }";
@@ -345,7 +345,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = $""This {noun} is\n \r\f \f \r {adjective}"";
+                Console.WriteLine($""This {noun} is\n \r\f \f \r {adjective}"");
             }
         }
     }";
@@ -365,7 +365,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(""This {0} is \""{1}\"""", noun, adjective);
+                Console.WriteLine(""This {0} is \""{1}\"""", noun, adjective);
             }
         }
     }";
@@ -379,7 +379,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = $""This {noun} is \""{adjective}\"""";
+                Console.WriteLine($""This {noun} is \""{adjective}\"""");
             }
         }
     }";
@@ -387,7 +387,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task VerbatimStringWithStringFormatCreatesDiagnostic()
+        public async Task VerbatimStringWithConsoleWriteLineCreatesDiagnostic()
         {
             const string source = @"
     using System;
@@ -399,17 +399,17 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(@""This {0} is
+                Console.WriteLine(@""This {0} is
 """"{1}""""."", noun, adjective);
             }
         }
     }";
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormat.ToDiagnosticId(),
-                Message = StringFormatAnalyzer.MessageFormat.ToString(),
+                Id = DiagnosticId.ConsoleWriteLine.ToDiagnosticId(),
+                Message = ConsoleWriteLineAnalyzer.MessageFormat.ToString(),
                 Severity = DiagnosticSeverity.Info,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 25) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 17) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
@@ -427,7 +427,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(@""This {0} is
+                Console.WriteLine(@""This {0} is
 """"{1}""""."", noun, adjective);
             }
         }
@@ -442,8 +442,8 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = $@""This {noun} is
-""""{adjective}""""."";
+                Console.WriteLine($@""This {noun} is
+""""{adjective}""""."");
             }
         }
     }";
@@ -461,7 +461,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var s = string.Format("" |{0, -15 :N5}| "", System.Math.PI);
+                Console.WriteLine("" |{0, -15 :N5}| "", System.Math.PI);
             }
         }
     }";
@@ -473,7 +473,7 @@ namespace CodeCracker.Test.CSharp.Style
         {
             void Foo()
             {
-                var s = $"" |{System.Math.PI, -15 :N5}| "";
+                Console.WriteLine($"" |{System.Math.PI, -15 :N5}| "");
             }
         }
     }";
@@ -481,7 +481,7 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task StringFormatChangesToStringInterpolationWithInvertedIndexes()
+        public async Task ConsoleWriteLineChangesToStringInterpolationWithInvertedIndexes()
         {
             const string source = @"
     using System;
@@ -494,7 +494,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 //comment before
-                var s = string.Format(""This {1} is {0}"", noun, adjective);//comment right after
+                Console.WriteLine(""This {1} is {0}"", noun, adjective);//comment right after
                 //comment after
             }
         }
@@ -510,7 +510,7 @@ namespace CodeCracker.Test.CSharp.Style
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
                 //comment before
-                var s = $""This {adjective} is {noun}"";//comment right after
+                Console.WriteLine($""This {adjective} is {noun}"");//comment right after
                 //comment after
             }
         }
@@ -519,9 +519,10 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
-        public async Task StringFormatWithTernaryOperatorFixesWithParenthesis()
+        public async Task ConsoleWriteLineWithTernaryOperatorFixesWithParenthesis()
         {
             const string source = @"
+    using System;
     namespace ConsoleApplication1
     {
         class TypeName
@@ -530,11 +531,12 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = string.Format(""This {0} is {1}"", noun, true ? adjective : noun);
+                Console.WriteLine(""This {0} is {1}"", noun, true ? adjective : noun);
             }
         }
     }";
             const string expected = @"
+    using System;
     namespace ConsoleApplication1
     {
         class TypeName
@@ -543,7 +545,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var noun = ""Giovanni"";
                 var adjective = ""smart"";
-                var s = $""This {noun} is {(true ? adjective : noun)}"";
+                Console.WriteLine($""This {noun} is {(true ? adjective : noun)}"");
             }
         }
     }";


### PR DESCRIPTION
Closes #380
Already using localization
Updated String.Format analyzer and code fix to use localization
and to the more performant code action.
Using common code for string.format and console.writeline.