### PR TITLE
Fix bug on CC0068 (RemovePrivateMethodNeverUsed) with Main #368

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
@@ -326,5 +326,24 @@ class Foo
 ";
             await VerifyCSharpFixAsync(source, fixtest);
         }
+
+        [Fact]
+        public async void MainMethodEntryPointWithDifferentReturnTypeShouldCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static string Main(string[] args)
+    {
+    }
+}
+";
+            const string fixtest = @"
+class Foo
+{
+}
+";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
@@ -227,5 +227,104 @@ class Foo
 ";
             await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
+
+        [Fact]
+        public async void MainMethodEntryPointReturningVoidDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static void Main(String[] args)
+    {
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void MainMethodEntryPointReturningIntegerDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static int Main(string[] args)
+    {
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void MainMethodEntryPointWithoutParameterDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static int Main()
+    {
+    }
+}
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async void MainMethodEntryPointWithoutStaticModifierShouldCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    int Main(string[] args)
+    {
+    }
+}
+";
+            const string fixtest = @"
+class Foo
+{
+}
+";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async void MainMethodEntryPointWithMoreThanOneParameterShouldCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static int Main(string[] args, string[] args2)
+    {
+    }
+}
+";
+            const string fixtest = @"
+class Foo
+{
+}
+";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async void MainMethodEntryPointWithDifferentParameterShouldCreateDiagnostic()
+        {
+            const string source = @"
+class Foo
+{
+    static int Main(string args)
+    {
+    }
+}
+";
+            const string fixtest = @"
+class Foo
+{
+}
+";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
     }
 }


### PR DESCRIPTION
Fixes CC0068 on #368

I've created and called a new method 'IsMainMethodEntryPoint' that verifies:
Method name is "Main";
Method is static;
Method returns 'Void' or 'Int32';
Method has more than 1 parameters;
Method has no parameter
Method has parameter type 'String[]'

And added respectives tests.