### PR TITLE
BugFix nameof analyzer (CC0021)

### DIFF
--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -62,6 +62,33 @@ public class TypeName()
         }
 
         [Fact]
+        public async Task IgnoreInVariableDeclaration()
+        {
+            const string test = @"
+public class TypeName()
+{
+    public TypeName()
+    {
+        var @var = string.IsNullOrEmpty(""var"");
+    }
+}";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task IgnoreOnPropertyDeclaration()
+        {
+            const string test = @"
+public class TypeName
+{
+    public string MyProperty { get; set; } = ""MyProperty"";
+}";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async Task WhenUsingSomeStringInAttributeShouldNotReportDiagnostic()
         {
             const string test = @"


### PR DESCRIPTION
Bug fix for #359. 
---
**Changes:**
- Added a check if the node is within a `VariableDeclaratorSyntax` or a `PropertyDeclarationSyntax`
- Added 2 new unit test to cover these cases.

I think this should fix the issue, maybe I am forgetting some edge case.