### PR TITLE
Removed parenthisis of empty constructor in object initializer code f…

### DIFF
--- a/src/CSharp/CodeCracker/Style/ObjectInitializerCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/ObjectInitializerCodeFixProvider.cs
@@ -97,6 +97,10 @@ namespace CodeCracker.CSharp.Style
                         .WithLeadingTrivia(objectCreationExpression.GetLeadingTrivia())
                         .WithTrailingTrivia(objectCreationExpression.GetTrailingTrivia())
                         .WithAdditionalAnnotations(Formatter.Annotation);
+                    if (newObjectCreationExpression.ArgumentList?.Arguments.Count == 0)
+                    {
+                        newObjectCreationExpression = newObjectCreationExpression.WithArgumentList(null);
+                    }
                     var newLocalDeclarationStatement = statement.ReplaceNode(objectCreationExpression, newObjectCreationExpression)
                         .WithLeadingTrivia(statement.GetLeadingTrivia())
                         .WithTrailingTrivia(statement.GetTrailingTrivia())

--- a/test/CSharp/CodeCracker.Test/Style/ObjectInitializerTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ObjectInitializerTests.cs
@@ -153,7 +153,7 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 string a;
                 //some comment before
-                var p = new Person()
+                var p = new Person
                 {
                     Name = ""Giovanni"",
                     Age = 25
@@ -447,7 +447,7 @@ namespace CodeCracker.Test.CSharp.Style
                 string a;
                 //some comment before
                 Person p;
-                p = new Person()
+                p = new Person
                 {
                     Name = ""Giovanni"",
                     Age = 25


### PR DESCRIPTION
Removed parenthesis of empty constructor in `ObjectInitializerCodeFixProvider`.
This prevents a CC0015 warning and fixes #383.

Sorry for not giving a heads up sooner. I was very quick to solve this issue.