### PR TITLE
Expanded CC0006 to deal with more array accessors

### DIFF
--- a/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ForInArrayAnalyzer.cs
@@ -43,12 +43,13 @@ namespace CodeCracker.CSharp.Style
             if (arrayAccessor == null) return;
             if (!arrayAccessor.IsKind(SyntaxKind.SimpleMemberAccessExpression)) return;
             var arrayId = context.SemanticModel.GetSymbolInfo(arrayAccessor.Expression).Symbol as ILocalSymbol;
-            var literalExpression = forStatement.Declaration.Variables.Single().Initializer.Value as LiteralExpressionSyntax;
+            var forVariable = forStatement.Declaration.Variables.Single();
+            var literalExpression = forVariable.Initializer.Value as LiteralExpressionSyntax;
             if (literalExpression == null || !literalExpression.IsKind(SyntaxKind.NumericLiteralExpression)) return;
             if (literalExpression.Token.ValueText != "0") return;
-            var controlVarId = context.SemanticModel.GetDeclaredSymbol(forStatement.Declaration.Variables.Single());
-            var otherUsesOfIndexToken = forBlock.DescendantTokens().Count(t => t.Text == forStatement.Declaration.Variables.Single().Identifier.Text);
-            if (otherUsesOfIndexToken != 1) return;
+            var controlVarId = context.SemanticModel.GetDeclaredSymbol(forVariable);
+            var otherUsesOfIndexToken = forBlock.DescendantTokens().Count(t => t.GetAncestor<ElementAccessExpressionSyntax>() == null && t.Text == forVariable.Identifier.Text);
+            if (otherUsesOfIndexToken != 0) return;
 
             var arrayAccessorSymbols = (from s in forBlock.Statements.OfType<LocalDeclarationStatementSyntax>()
                                         where s.Declaration.Variables.Count == 1

--- a/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ForInArrayTests.cs
@@ -411,6 +411,37 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
+        public async Task ForInArrayAnalyzerWhenHasMultipleElementAccessCreatesDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                var count = 0;
+                for (var i = 0; i < array.Length; i++)
+                {
+                    var item = array[i];
+                    count += array[i];
+                    Console.WriteLine(array[i]);
+                }
+            }
+        }
+    }";
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.ForInArray.ToDiagnosticId(),
+                Message = "You can use foreach instead of for.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
         public async Task WhenUsingForWithAnArrayThenChangesToForeach()
         {
             const string source = @"
@@ -447,6 +478,90 @@ namespace CodeCracker.Test.CSharp.Style
                     // whatever comes before
                     // whatever comes after
                     string b;
+                }
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
+        public async Task WhenUsingForWithAnArrayWithMultipleElementAccessThenChangesToForeach()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                var count = 0;
+                for (var i = 0; i < array.Length; i++)
+                {
+                    var item = array[i];
+                    count += array[i];
+                    Console.WriteLine(array[i]);
+                }
+            }
+        }
+    }";
+
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                var count = 0;
+                foreach (var item in array)
+                {
+                    count += item;
+                    Console.WriteLine(item);
+                }
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
+        public async Task WhenUsingForWithAnArrayWithMultipleArraysInBodyAndMultipleElementAccessThenChangesToForeach()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                var count = 0;
+                for (var i = 0; i < array.Length; i++)
+                {
+                    var item = array[i];
+                    count += array[i];
+                    anotherCount += anotherArray[i];
+                }
+            }
+        }
+    }";
+
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Bar()
+            {
+                var array = new [] {1};
+                var count = 0;
+                foreach (var item in array)
+                {
+                    count += item;
+                    anotherCount += anotherArray[i];
                 }
             }
         }


### PR DESCRIPTION
This PR Fix #318

Now CC0006 can deal with more array accessors, like this:
````csharp
var array = new [] {1};
var count = 0;
for (var i = 0; i < array.Length; i++)
{
    var item = array[i];
    count += array[i];
    Console.WriteLine(array[i]);
    count += array[array[i]];
}
````
CodeFix change old code to:
````csharp
var array = new [] {1};
var count = 0;
foreach (var item in array)
{
    count += item;
    Console.WriteLine(item);
    count += array[item];
}
````