### PR TITLE
Ignore Disposable objects created on return statements

### DIFF
--- a/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
@@ -37,6 +37,7 @@ namespace CodeCracker.CSharp.Usage
             var objectCreation = context.Node as ObjectCreationExpressionSyntax;
             if (objectCreation == null) return;
             if (objectCreation?.Parent is UsingStatementSyntax) return;
+            if (objectCreation?.Parent is ReturnStatementSyntax) return;
 
             var semanticModel = context.SemanticModel;
             var type = semanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;

--- a/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
@@ -779,5 +779,26 @@ m.Dispose();".WrapInCSharpMethod();
 ";
             await VerifyCSharpFixAllAsync(new[] { source1, source2, source3 }, new[] { fixtest1, fixtest2, fixtest3 });
         }
+
+        [Fact]
+        public async Task IgnoresDisposableObjectsBeingCreatedOnReturnStatement()
+        {
+            var source =
+             @"namespace MyNamespace
+                  {
+                        public class DisposableClass : System.IDisposable  { }
+                      
+                        public class ActualClass
+                        {
+                            public DisposableClass Method()
+                            {
+                                return new DisposableClass();
+                            }
+                        }
+                  }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
     }
 }


### PR DESCRIPTION
Fixed the ```DisposableVariableNotDisposedAnalyzer``` so it ignores nodes
whose Parents are of type ```ReturnStatementSyntax```

Closes #399.