### PR TITLE
Implemented analyzer to fix xml docs parameters

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -71,6 +71,9 @@
     <Compile Include="Refactoring\IntroduceFieldFromConstructorCodeFixProvider.cs" />
     <Compile Include="Refactoring\ParameterRefactoryAnalyzer.cs" />
     <Compile Include="Refactoring\ParameterRefactoryCodeFixProvider.cs" />
+    <Compile Include="Maintainability\XmlDocumentationAnalyzer.cs" />
+    <Compile Include="Maintainability\XmlDocumentationCreateMissingParametersCodeFixProvider.cs" />
+    <Compile Include="Maintainability\XmlDocumentationRemoveNonExistentParametersCodeFixProvider.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseAnalyzer.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseCodeFixProvider.cs" />
     <Compile Include="Style\ConsoleWriteLineAnalyzer.cs" />
@@ -99,6 +102,7 @@
     <Compile Include="Style\RemoveTrailingWhitespaceCodeFixProvider.cs" />
     <Compile Include="Style\StringFormatCodeFixProvider.cs" />
     <Compile Include="Refactoring\NumericLiteralAnalyzer.cs" />
+    <Compile Include="Maintainability\XmlDocumentationCodeFixProvider.cs" />
     <Compile Include="Usage\AbstractClassShouldNotHavePublicCtorsCodeFixProvider.cs" />
     <Compile Include="Usage\AbstractClassShouldNotHavePublicCtorsAnalyzer.cs" />
     <Compile Include="Usage\ArgumentExceptionAnalyzer.cs" />
@@ -250,7 +254,6 @@
   <ItemGroup>
     <Folder Include="Globalization\" />
     <Folder Include="Interoperability\" />
-    <Folder Include="Maintainability\" />
     <Folder Include="Mobility\" />
     <Folder Include="Naming\" />
     <Folder Include="Portability\" />

--- a/src/CSharp/CodeCracker/Maintainability/XmlDocumentationAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Maintainability/XmlDocumentationAnalyzer.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using CodeCracker.Properties;
+
+namespace CodeCracker.CSharp.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class XmlDocumentationAnalyzer : DiagnosticAnalyzer
+    {
+        internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.XmlDocumentationAnalyzer_Title), Resources.ResourceManager, typeof(Resources));
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId.XmlDocumentation.ToDiagnosticId(),
+            Title,
+            Title,
+            SupportedCategories.Maintainability,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.XmlDocumentation));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.SingleLineDocumentationCommentTrivia);
+
+        private static void Analyzer(SyntaxNodeAnalysisContext context)
+        {
+            var documentationNode = (DocumentationCommentTriviaSyntax)context.Node;
+            var method = documentationNode.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
+            var methodParameters = method.ParameterList.Parameters;
+            var xElementsWitAttrs = documentationNode.Content.OfType<XmlElementSyntax>()
+                                    .Where(xEle => xEle.StartTag.Name.LocalName.ValueText == "param")
+                                    .SelectMany(xEle => xEle.StartTag.Attributes, (xEle, attr) => (XmlNameAttributeSyntax)attr);
+
+            var keys = methodParameters.Select(parameter => parameter.Identifier.ValueText)
+                .Union(xElementsWitAttrs.Select(x => x.Identifier.Identifier.ValueText))
+                .ToImmutableHashSet();
+
+            var paramterWithDocParameter = (from key in keys
+                                            let Parameter = methodParameters.FirstOrDefault(p => p.Identifier.ValueText == key)
+                                            let DocParameter = xElementsWitAttrs.FirstOrDefault(p => p.Identifier.Identifier.ValueText == key)
+                                            select new { Parameter, DocParameter });
+
+            if (paramterWithDocParameter.Any(p => p.Parameter == null))
+            {
+                var properties = new Dictionary<string, string> {["kind"] = "nonexistentParam" }.ToImmutableDictionary();
+                var diagnostic = Diagnostic.Create(Rule, documentationNode.GetLocation(), properties);
+                context.ReportDiagnostic(diagnostic);
+            }
+
+            if (paramterWithDocParameter.Any(p => p.DocParameter == null))
+            {
+                var properties = new Dictionary<string, string> { ["kind"] = "missingDoc" }.ToImmutableDictionary();
+                var diagnostic = Diagnostic.Create(Rule, documentationNode.GetLocation(), properties);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Maintainability/XmlDocumentationCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Maintainability/XmlDocumentationCodeFixProvider.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodeCracker.CSharp.Maintainability
+{
+    public abstract class XmlDocumentationCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.XmlDocumentation.ToDiagnosticId());
+
+        public abstract SyntaxNode FixParameters(MethodDeclarationSyntax method, SyntaxNode root);
+
+        protected async Task<Document> FixParametersAsync(Document document, Diagnostic diagnostic, CancellationToken c)
+        {
+            var root = await document.GetSyntaxRootAsync(c).ConfigureAwait(false);
+            var documentationNode = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
+            var newRoot = FixParameters(documentationNode, root);
+            var newDocument = document.WithSyntaxRoot(newRoot);
+
+            return newDocument;
+        }
+
+        protected static IEnumerable<Tuple<ParameterSyntax, Tuple<XmlElementSyntax, XmlNameAttributeSyntax>>> GetMethodParametersWithDocParameters(MethodDeclarationSyntax method, DocumentationCommentTriviaSyntax documentationNode)
+        {
+            var methodParameters = method.ParameterList.Parameters;
+
+            var xElementsWitAttrs = documentationNode.Content.OfType<XmlElementSyntax>()
+                                    .Where(xEle => xEle.StartTag.Name.LocalName.ValueText == "param")
+                                    .SelectMany(xEle => xEle.StartTag.Attributes, (xEle, attr) => new Tuple<XmlElementSyntax, XmlNameAttributeSyntax>(xEle, (XmlNameAttributeSyntax)attr));
+
+            var keys = methodParameters.Select(parameter => parameter.Identifier.ValueText)
+                .Union(xElementsWitAttrs.Select(x => x.Item2.Identifier.Identifier.ValueText))
+                .ToImmutableHashSet();
+
+            return (from key in keys
+                    let Parameter = methodParameters.FirstOrDefault(p => p.Identifier.ValueText == key)
+                    let DocParameter = xElementsWitAttrs.FirstOrDefault(p => p.Item2.Identifier.Identifier.ValueText == key)
+                    select new Tuple<ParameterSyntax, Tuple<XmlElementSyntax, XmlNameAttributeSyntax>>(Parameter, DocParameter));
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Maintainability/XmlDocumentationCreateMissingParametersCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Maintainability/XmlDocumentationCreateMissingParametersCodeFixProvider.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+
+namespace CodeCracker.CSharp.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, nameof(XmlDocumentationCodeFixProvider)), Shared]
+    public class XmlDocumentationCreateMissingParametersCodeFixProvider : XmlDocumentationCodeFixProvider
+    {
+        public override SyntaxNode FixParameters(MethodDeclarationSyntax method, SyntaxNode root)
+        {
+            var documentationNode = method.GetLeadingTrivia().Select(x => x.GetStructure()).OfType<DocumentationCommentTriviaSyntax>().First();
+            var newDocumentationNode = documentationNode;
+            var methodParameterWithDocParameter = GetMethodParametersWithDocParameters(method, documentationNode);
+
+            var xmlText = documentationNode.Content.OfType<XmlTextSyntax>().Skip(1).First();
+
+            var nodesToAdd = methodParameterWithDocParameter.Where(p => p.Item2 == null)
+                                .SelectMany(x => CreateParamenterXmlDocumentation(xmlText, x.Item1.Identifier.ValueText, method.Identifier.ValueText))
+                                .ToList();
+            var newFormation = newDocumentationNode.Content.OfType<XmlElementSyntax>().ToList();
+            var node = newFormation.LastOrDefault(xEle => xEle.StartTag.Name.LocalName.ValueText == "param") ?? newFormation.LastOrDefault(xEle => xEle.StartTag.Name.LocalName.ValueText == "summary");
+            var nodeInList = documentationNode.Content.OfType<XmlTextSyntax>().FirstOrDefault(x => x.FullSpan.Start == node.FullSpan.End);
+
+            newDocumentationNode = newDocumentationNode.InsertNodesAfter(node, nodesToAdd.Cast<SyntaxNode>());
+
+            return root.ReplaceNode(documentationNode, newDocumentationNode);
+        }
+
+
+        private static XmlNodeSyntax[] CreateParamenterXmlDocumentation(XmlTextSyntax xmlText, string paramenterName, string methodName)
+        {
+            var content = $"todo: describe {paramenterName} parameter on {methodName}";
+            var xmlTagName = SyntaxFactory.XmlName(SyntaxFactory.Identifier(@"param "));
+            var startTag = SyntaxFactory.XmlElementStartTag(xmlTagName).WithAttributes(CreateXmlAttributes(paramenterName));
+            var endTag = SyntaxFactory.XmlElementEndTag(SyntaxFactory.XmlName(SyntaxFactory.Identifier(@"param")));
+
+            var xmlElementSyntax = SyntaxFactory.XmlElement(startTag, endTag).WithContent(CreateXmlElementContent(content));
+
+            return new XmlNodeSyntax[] { xmlText, xmlElementSyntax };
+        }
+
+        private static SyntaxList<XmlNodeSyntax> CreateXmlElementContent(string content)
+        {
+            var triviaList = SyntaxFactory.TriviaList();
+            var xmlTextLiteral = SyntaxFactory.XmlTextLiteral(triviaList, content, content, triviaList);
+            return SyntaxFactory.SingletonList<XmlNodeSyntax>(SyntaxFactory.XmlText(SyntaxFactory.TokenList(xmlTextLiteral)));
+        }
+
+        private static SyntaxList<XmlAttributeSyntax> CreateXmlAttributes(string paramenterName)
+        {
+            var syntaxToken = SyntaxFactory.Token(DoubleQuoteToken);
+            var xmlAttributeName = SyntaxFactory.XmlName(SyntaxFactory.Identifier(@"name"));
+
+            return SyntaxFactory.SingletonList<XmlAttributeSyntax>(SyntaxFactory.XmlNameAttribute(xmlAttributeName, syntaxToken, SyntaxFactory.IdentifierName(paramenterName), syntaxToken));
+        }
+
+        public override sealed Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            if (diagnostic.Properties["kind"] == "missingDoc")
+                context.RegisterCodeFix(CodeAction.Create(Resources.XmlDocumentationCreateMissingParametersCodeFixProvider_Title, c => FixParametersAsync(context.Document, diagnostic, c)), diagnostic);
+            return Task.FromResult(0);
+        }
+    }
+
+
+}

--- a/src/CSharp/CodeCracker/Maintainability/XmlDocumentationRemoveNonExistentParametersCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Maintainability/XmlDocumentationRemoveNonExistentParametersCodeFixProvider.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+
+namespace CodeCracker.CSharp.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, nameof(XmlDocumentationCodeFixProvider)), Shared]
+    public class XmlDocumentationRemoveNonExistentParametersCodeFixProvider : XmlDocumentationCodeFixProvider
+    {
+        public override SyntaxNode FixParameters(MethodDeclarationSyntax method, SyntaxNode root)
+        {
+            var documentationNode = method.GetLeadingTrivia().Select(x => x.GetStructure()).OfType<DocumentationCommentTriviaSyntax>().First();
+
+            var allNodesToRemove = GetAllNodesToRemove(GetMethodParametersWithDocParameters(method, documentationNode), documentationNode);
+
+            var newDocumentationNode = documentationNode.RemoveNodes(allNodesToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+
+            return root.ReplaceNode(documentationNode, newDocumentationNode);
+        }
+
+        private static IEnumerable<SyntaxNode> GetAllNodesToRemove(IEnumerable<Tuple<ParameterSyntax, Tuple<XmlElementSyntax, XmlNameAttributeSyntax>>> paramterWithDocParameter, DocumentationCommentTriviaSyntax documentationNode)
+        {
+            var nodesToRemove = paramterWithDocParameter.Where(p => p.Item1 == null).Select(x => x.Item2.Item1).ToList();
+
+            var xmlTextNodesToRemove = documentationNode.Content.OfType<XmlTextSyntax>()
+                .Join(nodesToRemove, textNode => textNode.FullSpan.End, tagNode => tagNode.FullSpan.Start, (textNode, tagNode) => textNode);
+
+            var allNodesToRemove = nodesToRemove.Cast<SyntaxNode>().Union(xmlTextNodesToRemove);
+            return allNodesToRemove;
+        }
+
+        public override sealed Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            if (diagnostic.Properties["kind"] == "nonexistentParam")
+                context.RegisterCodeFix(CodeAction.Create(Resources.XmlDocumentationRemoveNonExistentParametersCodeFixProvider_Title, c => FixParametersAsync(context.Document, diagnostic, c)), diagnostic);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -73,6 +73,7 @@
         UseStringEmpty = 84,
         UseEmptyString = 88,
         RemoveRedundantElseClause = 89,
+        XmlDocumentation = 90,
         MakeMethodStatic = 91,
         ChangeAllToAny = 92,
         ConsoleWriteLine = 95,

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -231,5 +231,32 @@ namespace CodeCracker.Properties {
                 return ResourceManager.GetString("StringFormatCodeFixProvider_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You have missing/unexistent parameters in Xml Docs.
+        /// </summary>
+        public static string XmlDocumentationAnalyzer_Title {
+            get {
+                return ResourceManager.GetString("XmlDocumentationAnalyzer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create missing parameters in xml docs.
+        /// </summary>
+        public static string XmlDocumentationCreateMissingParametersCodeFixProvider_Title {
+            get {
+                return ResourceManager.GetString("XmlDocumentationCreateMissingParametersCodeFixProvider_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove unexistent parameters in xml docs.
+        /// </summary>
+        public static string XmlDocumentationRemoveNonExistentParametersCodeFixProvider_Title {
+            get {
+                return ResourceManager.GetString("XmlDocumentationRemoveNonExistentParametersCodeFixProvider_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -174,4 +174,13 @@
   <data name="MakeMethodNonAsyncCodeFixProvider_Title" xml:space="preserve">
     <value>Make method non async</value>
   </data>
+  <data name="XmlDocumentationAnalyzer_Title" xml:space="preserve">
+    <value>You have missing/unexistent parameters in Xml Docs</value>
+  </data>
+  <data name="XmlDocumentationCreateMissingParametersCodeFixProvider_Title" xml:space="preserve">
+    <value>Create missing parameters in xml docs</value>
+  </data>
+  <data name="XmlDocumentationRemoveNonExistentParametersCodeFixProvider_Title" xml:space="preserve">
+    <value>Remove unexistent parameters in xml docs</value>
+  </data>
 </root>

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Style\TaskNameASyncTests.cs" />
     <Compile Include="Style\RemoveAsyncFromMethodTests.cs" />
     <Compile Include="Refactoring\NumericLiteralTests.cs" />
+    <Compile Include="Style\XmlDocumentationAnalyzerTests.cs" />
     <Compile Include="Usage\AbstractClassShouldNotHavePublicCtorTests.cs" />
     <Compile Include="Usage\ArgumentExceptionTests.cs" />
     <Compile Include="Style\ConvertToSwitchTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Style/XmlDocumentationAnalyzerTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/XmlDocumentationAnalyzerTests.cs
@@ -1,0 +1,283 @@
+﻿using CodeCracker.CSharp.Maintainability;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Style
+{
+
+    public class XmlDocumentationAnalyzerTests : CodeFixVerifier<XmlDocumentationAnalyzer, XmlDocumentationRemoveNonExistentParametersCodeFixProvider>
+    {
+        [Fact]
+        public async Task XmlDocumentationWithUnexistentParameterOfMethodAnalyzerCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""analyzer"">The analyzer to run on the documents</param>
+            /// <param name=""documents"">The Documents that the analyzer will be run on</param>
+            /// <param name=""spans"">Optional TextSpan indicating where a Diagnostic will be found</param>
+            /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
+            protected async static Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
+            {
+            }
+        }
+    }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.XmlDocumentation.ToDiagnosticId(),
+                Message = "You have missing/unexistent parameters in Xml Docs",
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 16) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task XmlDocumentationWithMissingParametersFromMethodAnalyzerCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""sources"">Classes in the form of strings</param>
+            /// <param name=""language"">The language the source code is in</param>
+            /// <returns>A Project created out of the Douments created from the source strings</returns>
+            public static Project CreateProject(string[] sources, out AdhocWorkspace workspace, string language = LanguageNames.CSharp)
+            {
+            }
+        }
+    }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.XmlDocumentation.ToDiagnosticId(),
+                Message = "You have missing/unexistent parameters in Xml Docs",
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 16) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task XmlDocumentationWithMatchingParametersFromMethodAnalyzerDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""value"" ></param>
+            /// <returns></returns>
+            public int Foo(int value)
+            {
+            }
+    }
+    }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task MethodWithoutXmlDocumentationAnalyzerDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int Foo(int value)
+            {
+            }
+    }
+    }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+    }
+
+    public class XmlDocumentationRemoveUnexistentParametersCodeFixTests : CodeFixVerifier<XmlDocumentationAnalyzer, XmlDocumentationRemoveNonExistentParametersCodeFixProvider>
+    {
+        [Fact]
+        public async Task FixRemoveParameterDoc()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""analyzer"">The analyzer to run on the documents</param>
+            /// <param name=""documents"">The Documents that the analyzer will be run on</param>
+            /// <param name=""spans"">Optional TextSpan indicating where a Diagnostic will be found</param>
+            /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
+            protected async static Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
+            {
+            }
+        }
+    }";
+
+            const string expected = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""analyzer"">The analyzer to run on the documents</param>
+            /// <param name=""documents"">The Documents that the analyzer will be run on</param>
+            /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
+            protected async static Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
+            {
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task FixRemoveManyParameterDoc()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""analyzer"">The analyzer to run on the documents</param>
+            /// <param name=""anotherToBeRemoved"">Optional TextSpan indicating where a Diagnostic will be found</param>
+            /// <param name=""documents"">The Documents that the analyzer will be run on</param>
+            /// <param name=""spansToBeRemoved"">Optional TextSpan indicating where a Diagnostic will be found</param>
+            /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
+            protected async static Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
+            {
+            }
+        }
+    }";
+
+            const string expected = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""analyzer"">The analyzer to run on the documents</param>
+            /// <param name=""documents"">The Documents that the analyzer will be run on</param>
+            /// <returns>An IEnumerable of Diagnostics that surfaced in teh source code, sorted by Location</returns>
+            protected async static Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
+            {
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, expected);
+        }
+
+
+    }
+
+    public class XmlDocumentationCreateMissingParametersCodeFixTests : CodeFixVerifier<XmlDocumentationAnalyzer, XmlDocumentationCreateMissingParametersCodeFixProvider>
+    {
+        [Fact]
+        public async Task FixCreateOneParameterDoc()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""sources"">Classes in the form of strings</param>
+            /// <param name=""language"">The language the source code is in</param>
+            /// <returns>A Project created out of the Douments created from the source strings</returns>
+            public static Project CreateProject(string[] sources, out AdhocWorkspace workspace, string language = LanguageNames.CSharp)
+            {
+            }
+        }
+    }";
+
+            const string expected = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""sources"">Classes in the form of strings</param>
+            /// <param name=""language"">The language the source code is in</param>
+            /// <param name=""workspace"">todo: describe workspace parameter on CreateProject</param>
+            /// <returns>A Project created out of the Douments created from the source strings</returns>
+            public static Project CreateProject(string[] sources, out AdhocWorkspace workspace, string language = LanguageNames.CSharp)
+            {
+            }
+        }
+    }";
+
+            await VerifyCSharpFixAsync(source, expected);
+        }
+
+
+        [Fact]
+        public async Task FixCreateManyParameterDoc()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <returns>A Project created out of the Douments created from the source strings</returns>
+            public static Project CreateProject(string[] sources, out AdhocWorkspace workspace, string language = LanguageNames.CSharp)
+            {
+            }
+        }
+    }";
+
+            const string expected = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {    
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name=""sources"">todo: describe sources parameter on CreateProject</param>
+            /// <param name=""workspace"">todo: describe workspace parameter on CreateProject</param>
+            /// <param name=""language"">todo: describe language parameter on CreateProject</param>
+            /// <returns>A Project created out of the Douments created from the source strings</returns>
+            public static Project CreateProject(string[] sources, out AdhocWorkspace workspace, string language = LanguageNames.CSharp)
+            {
+            }
+        }
+    }";
+
+            await VerifyCSharpFixAsync(source, expected);
+        }
+    }
+}


### PR DESCRIPTION
I created analyzer and 2 code fixes, one for missing parameters and another to unexisting parameters.

Tests are ok, but I am facing a problem when testing running VS 

But when I press <kbd>CTRL</kbd>+<kbd>.</kbd> I get a error in VS.
**"One or more erros ocurred."**

When I checked to see all exceptions in VS I got StackTrace and got this exception:
````
System.InvalidCastException occurred
Message: Exception thrown: 'System.InvalidCastException' in mscorlib.dll
Additional information: Unable to cast object of type 'System.Reflection.RuntimeMethodInfo' to type 'System.Reflection.ConstructorInfo'.
````

I tried a lot things, but couldnt fix, I need help.
Fix #357 