### PR TITLE
Fix #408. Nameof now ignores not yet declared locals

### DIFF
--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -69,6 +69,13 @@ namespace CodeCracker.CSharp.Design
                 var literalValueText = stringLiteral.Token.ValueText;
                 var symbol = semanticModel.LookupSymbols(stringLiteral.Token.SpanStart, null, literalValueText).FirstOrDefault();
 
+                if (symbol?.Kind == SymbolKind.Local)
+                {
+                    var symbolSpan = symbol.Locations.Min(i => i.SourceSpan);
+                    if (symbolSpan.CompareTo(stringLiteral.Token.Span) > 0)
+                        return string.Empty;
+                }
+
                 programElementName = symbol?.ToDisplayParts().LastOrDefault(IncludeOnlyPartsThatAreName).ToString();
             }
 

--- a/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/NameOfTests.cs
@@ -89,6 +89,21 @@ public class TypeName
         }
 
         [Fact]
+        public async Task IgnoreNamesNotDeclaredYet()
+        {
+            const string test = @"
+public class TypeName
+{
+    void Foo()
+    {
+        var str = ""x"";
+        var x = 1;
+    }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async Task WhenUsingSomeStringInAttributeShouldNotReportDiagnostic()
         {
             const string test = @"


### PR DESCRIPTION
Nameof now ignores not yet declared locals
---
This PR fixes #408.
Changes:
- Check if the symbol is a local and if so make sure that it is declared before the string.

-
Sorry for not letting you know I was working on it, just started on it tonight. If a issue takes me more than couple of hours to finish I will ask if I can work on it :+1:  