### PR TITLE
Fix #424 forTaskNameAsyncAnalyzer with new or overrides modifiers

### DIFF
--- a/src/CSharp/CodeCracker/Style/TaskNameAsyncAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/TaskNameAsyncAnalyzer.cs
@@ -33,6 +33,7 @@ namespace CodeCracker.CSharp.Style
             if (context.IsGenerated()) return;
             var method = (MethodDeclarationSyntax)context.Node;
             if (method.Identifier.ToString().EndsWith("Async")) return;
+            if (method.Modifiers.Any(SyntaxKind.NewKeyword, SyntaxKind.OverrideKeyword)) return;
 
             var errorMessage = method.Identifier.ToString() + "Async";
             var diag = Diagnostic.Create(Rule, method.Identifier.GetLocation(), errorMessage);

--- a/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
@@ -24,6 +24,40 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
+        public async Task TaskNameAsyncMethodWhithoutAsyncNameAndOverridesShouldNotCreateDiagnostic()
+        {
+            const string source = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            overrides Task Test() {};
+        }
+    }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task TaskNameAsyncMethodWhithoutAsyncNameAndShadowsShouldNotCreateDiagnostic()
+        {
+            const string source = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            new Task Test() {};
+        }
+    }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task TaskNameAsyncMethodWhithoutAsyncName()
         {
             const string source = @"
@@ -39,7 +73,7 @@ namespace CodeCracker.Test.CSharp.Style
             var expected = new DiagnosticResult
             {
                 Id = DiagnosticId.TaskNameAsync.ToDiagnosticId(),
-                Message = string.Format(TaskNameAsyncAnalyzer.MessageFormat,"TestAsync"),
+                Message = string.Format(TaskNameAsyncAnalyzer.MessageFormat, "TestAsync"),
                 Severity = DiagnosticSeverity.Info,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 18) }
             };


### PR DESCRIPTION
Ensure async methods with the new or overrides modifier are not flagged to be renamed by the TaskNameAsyncAnalyzer.