### PR TITLE
Fix #432. Disposable Instantiation on constructor call 

### DIFF
--- a/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfAnalyzer.cs
@@ -76,7 +76,7 @@ namespace CodeCracker.CSharp.Design
                         return string.Empty;
                 }
 
-                programElementName = symbol?.ToDisplayParts().LastOrDefault(IncludeOnlyPartsThatAreName).ToString();
+                programElementName = symbol?.ToDisplayParts().LastOrDefault(AnalyzerExtensions.IsName).ToString();
             }
 
             return programElementName;
@@ -109,9 +109,6 @@ namespace CodeCracker.CSharp.Design
         }
 
         private static bool Found(string programElement) => !string.IsNullOrEmpty(programElement);
-
-        public static bool IncludeOnlyPartsThatAreName(SymbolDisplayPart displayPart) =>
-            displayPart.IsAnyKind(SymbolDisplayPartKind.ClassName, SymbolDisplayPartKind.DelegateName, SymbolDisplayPartKind.EnumName, SymbolDisplayPartKind.EventName, SymbolDisplayPartKind.FieldName, SymbolDisplayPartKind.InterfaceName, SymbolDisplayPartKind.LocalName, SymbolDisplayPartKind.MethodName, SymbolDisplayPartKind.NamespaceName, SymbolDisplayPartKind.ParameterName, SymbolDisplayPartKind.PropertyName, SymbolDisplayPartKind.StructName);
 
         private static ParameterSyntax GetParameterWithIdentifierEqualToStringLiteral(LiteralExpressionSyntax stringLiteral, SeparatedSyntaxList<ParameterSyntax> parameters) =>
             parameters.FirstOrDefault(m => string.Equals(m.Identifier.ValueText, stringLiteral.Token.ValueText, StringComparison.Ordinal));

--- a/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/NameOfCodeFixProvider.cs
@@ -49,7 +49,7 @@ namespace CodeCracker.CSharp.Design
                 return parameter.Identifier.Text;
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var symbol = semanticModel.LookupSymbols(stringLiteral.Token.SpanStart, null, stringLiteral.Token.ValueText).First();
-            return symbol.ToDisplayParts().Last(NameOfAnalyzer.IncludeOnlyPartsThatAreName).ToString();
+            return symbol.ToDisplayParts().Last(AnalyzerExtensions.IsName).ToString();
         }
 
         private static ParameterSyntax FindParameterThatStringLiteralRefers(SyntaxNode root, int diagnosticSpanStart, LiteralExpressionSyntax stringLiteral)

--- a/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
@@ -38,6 +38,8 @@ namespace CodeCracker.CSharp.Usage
             if (objectCreation == null) return;
             if (objectCreation?.Parent is UsingStatementSyntax) return;
             if (objectCreation?.Parent is ReturnStatementSyntax) return;
+            if (objectCreation.FirstAncestorOfType<ConstructorInitializerSyntax>()?.Kind() == SyntaxKind.ThisConstructorInitializer) return;
+            if (objectCreation.FirstAncestorOfType<ObjectCreationExpressionSyntax>() != null) return;
 
             var semanticModel = context.SemanticModel;
             var type = semanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;

--- a/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
@@ -38,8 +38,8 @@ namespace CodeCracker.CSharp.Usage
             if (objectCreation == null) return;
             if (objectCreation?.Parent is UsingStatementSyntax) return;
             if (objectCreation?.Parent is ReturnStatementSyntax) return;
-            if (objectCreation.FirstAncestorOfType<ConstructorInitializerSyntax>()?.Kind() == SyntaxKind.ThisConstructorInitializer) return;
-            if (objectCreation.FirstAncestorOfType<ObjectCreationExpressionSyntax>() != null) return;
+            if (objectCreation.Ancestors().Any(i => i.IsKind(SyntaxKind.ThisConstructorInitializer))) return;
+            if (objectCreation.Ancestors().Any(i => i.IsKind(SyntaxKind.ObjectCreationExpression))) return;
 
             var semanticModel = context.SemanticModel;
             var type = semanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;

--- a/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedCodeFixProvider.cs
@@ -66,9 +66,8 @@ namespace CodeCracker.CSharp.Usage
             {
                 var identifierName = GetIdentifierName(objectCreation, semanticModel);
 
-                var whiteSpace = SyntaxFactory.Whitespace(" ");
-                var variableDeclaration = SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(@"var").WithTrailingTrivia(whiteSpace))
-                    .WithVariables(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(identifierName).WithTrailingTrivia(whiteSpace))
+                var variableDeclaration = SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(@"var"))
+                    .WithVariables(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(identifierName))
                     .WithInitializer(SyntaxFactory.EqualsValueClause(SyntaxFactory.Token(SyntaxKind.EqualsToken), objectCreation))));
 
                 var arg = objectCreation.Parent as ArgumentSyntax;
@@ -109,16 +108,16 @@ namespace CodeCracker.CSharp.Usage
             if (type.IsKind(SyntaxKind.QualifiedName))
             {
                 var name = (QualifiedNameSyntax)type;
-                identifierName = LoverCaseFirstLetter(name.Right.Identifier.ValueText);
+                identifierName = LowerCaseFirstLetter(name.Right.Identifier.ValueText);
             }
             else if (type is SimpleNameSyntax)
             {
                 var name = (SimpleNameSyntax)type;
-                identifierName = LoverCaseFirstLetter(name.Identifier.ValueText);
+                identifierName = LowerCaseFirstLetter(name.Identifier.ValueText);
             }
 
             var confilctingNames = from symbol in semanticModel.LookupSymbols(objectCreation.SpanStart)
-                                   let symbolIdentifierName = symbol?.ToDisplayParts().LastOrDefault(IncludeOnlyPartsThatAreName).ToString()
+                                   let symbolIdentifierName = symbol?.ToDisplayParts().LastOrDefault(AnalyzerExtensions.IsName).ToString()
                                    where symbolIdentifierName != null && symbolIdentifierName.StartsWith(identifierName)
                                    select symbolIdentifierName;
 
@@ -127,11 +126,7 @@ namespace CodeCracker.CSharp.Usage
             return identifierName + (identifierPostFix == 0 ? "" : identifierPostFix.ToString());
         }
 
-        private static string LoverCaseFirstLetter(string name) => char.ToLowerInvariant(name[0]) + name.Substring(1);
-        public static bool IncludeOnlyPartsThatAreName(SymbolDisplayPart displayPart) =>
-     displayPart.IsAnyKind(SymbolDisplayPartKind.ClassName, SymbolDisplayPartKind.DelegateName, SymbolDisplayPartKind.EnumName, SymbolDisplayPartKind.EventName, SymbolDisplayPartKind.FieldName, SymbolDisplayPartKind.InterfaceName, SymbolDisplayPartKind.LocalName, SymbolDisplayPartKind.MethodName, SymbolDisplayPartKind.NamespaceName, SymbolDisplayPartKind.ParameterName, SymbolDisplayPartKind.PropertyName, SymbolDisplayPartKind.StructName);
-
-
+        private static string LowerCaseFirstLetter(string name) => char.ToLowerInvariant(name[0]) + name.Substring(1);
 
         private static SyntaxNode CreateRootAddingDisposeToEndOfMethod(SyntaxNode root, ExpressionStatementSyntax statement, ILocalSymbol identitySymbol)
         {

--- a/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
+++ b/src/Common/CodeCracker.Common/Extensions/AnalyzerExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +7,14 @@ namespace CodeCracker
 {
     public static partial class AnalyzerExtensions
     {
+        public static bool IsName(this SymbolDisplayPart displayPart) =>
+            displayPart.IsAnyKind(SymbolDisplayPartKind.ClassName, SymbolDisplayPartKind.DelegateName,
+                                  SymbolDisplayPartKind.EnumName, SymbolDisplayPartKind.EventName,
+                                  SymbolDisplayPartKind.FieldName, SymbolDisplayPartKind.InterfaceName,
+                                  SymbolDisplayPartKind.LocalName, SymbolDisplayPartKind.MethodName,
+                                  SymbolDisplayPartKind.NamespaceName, SymbolDisplayPartKind.ParameterName,
+                                  SymbolDisplayPartKind.PropertyName, SymbolDisplayPartKind.StructName);
+
         public static SyntaxNode WithSameTriviaAs(this SyntaxNode target, SyntaxNode source)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));

--- a/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
@@ -75,6 +75,50 @@ m.Dispose();".WrapInCSharpMethod();
         }
 
         [Fact]
+        public async Task PassedIntoThisDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+                class A
+                {
+                    public A(Disposable foo)
+                    { }
+
+                    A() : this(new Disposable())
+                    { }
+                }
+
+                class Disposable : System.IDisposable
+                {
+                    void System.IDisposable.Dispose() { }
+                }
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task PassedToConstructorDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+                class A
+                {
+                    public A(Disposable foo)
+                    { }
+                    
+                    void Foo()
+                    { 
+                        var a = new A(new Disposable());
+                    }
+                }
+
+                class Disposable : System.IDisposable
+                {
+                    void System.IDisposable.Dispose() { }
+                }
+";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task DisposableVariablePassedAsParamCreatesDiagnostic()
         {
             var source = "string.Format(\"\", new System.IO.MemoryStream());".WrapInCSharpMethod();
@@ -338,6 +382,119 @@ using (m = new System.IO.MemoryStream())
 {
     Console.WriteLine(m);
 }".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAssignmentInsideArgument()
+        {
+            var source = @"
+{
+    string.Format(string.Empty,new System.IO.MemoryStream());
+}".WrapInCSharpMethod();
+            var fixtest = @"
+{
+    using (var memoryStream = new System.IO.MemoryStream())
+    {
+        string.Format(string.Empty, memoryStream);
+    }
+}".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAssignmentInsideArgumentWithSimpleName()
+        {
+            var source = @"
+{
+    string.Format(string.Empty,new MemoryStream());
+    var s = string.empty;
+}".WrapInCSharpMethod(usings: "using System.IO;");
+            var fixtest = @"
+{
+    using (var memoryStream = new MemoryStream())
+    {
+        string.Format(string.Empty, memoryStream);
+    }
+    var s = string.empty;
+}".WrapInCSharpMethod(usings: "using System.IO;");
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAssignmentInsideArgumentWithAssgienmt()
+        {
+            var source = @"
+{
+    var s = string.Format(string.Empty,new MemoryStream());
+    s.Trim();
+}".WrapInCSharpMethod(usings: "using System.IO;");
+            var fixtest = @"
+{
+    using (var memoryStream = new MemoryStream())
+    {
+        var s = string.Format(string.Empty, memoryStream);
+        s.Trim();
+    }
+}".WrapInCSharpMethod(usings: "using System.IO;");
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAssignmentInsideArgumentWithVariables()
+        {
+            var source = @"
+{
+    var s = string.Empty;
+    string.Format(s,new System.IO.MemoryStream());
+    s.Trim();
+}".WrapInCSharpMethod();
+            var fixtest = @"
+{
+    var s = string.Empty;
+    using (var memoryStream = new System.IO.MemoryStream())
+    {
+        string.Format(s, memoryStream);
+    }
+    s.Trim();
+}".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAssignmentInsideArgumentWithGenericName()
+        {
+            const string source = @"
+                class A
+                {
+                    void Foo()
+                    {
+                        string.Format(string.Empty,new Disposable<int>());
+                    }
+                }
+                class Disposable<T> : System.IDisposable
+                {
+                    void IDisposable.Dispose() { }
+                    public void Flush() { }
+                }
+";
+            const string fixtest = @"
+                class A
+                {
+                    void Foo()
+                    {    
+                        using (var disposable = new Disposable<int>())
+                        {
+                            string.Format(string.Empty, disposable);
+                        }
+                    }
+                }
+                class Disposable<T> : System.IDisposable
+                {
+                    void IDisposable.Dispose() { }
+                    public void Flush() { }
+                }
+";
             await VerifyCSharpFixAsync(source, fixtest);
         }
 


### PR DESCRIPTION
Potental Fix for #432.

Changes
-
- Added two checks to not raise when used in 
 - ThisConstructorInitializer, ```Foo() : this(new DisposableObject())```
 - ObjectCreationExpression ```new Bar(new DisposableObject())```
- Expanded the Code Fix to also provide a fix for disposable object passed as arguments.

```CSharp
string.Format(string.Empty,new Disposable());

// Becomes:

using (var disposable = new Disposable())
{
    string.Format(string.Empty, disposable);
}
```