### PR TITLE
Fix #452 for both CSharp and VB with proper casting.

### DIFF
--- a/src/CSharp/CodeCracker/Usage/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
@@ -49,7 +49,8 @@ namespace CodeCracker.CSharp.Usage
                 {
                     var invocation = statement.Expression as InvocationExpressionSyntax;
                     var method = invocation?.Expression as MemberAccessExpressionSyntax;
-                    if (method != null && ((IdentifierNameSyntax)method.Expression).Identifier.ToString() == "GC" && method.Name.ToString() == "SuppressFinalize")
+                    var identifierSyntax = method?.Expression as IdentifierNameSyntax;
+                    if (identifierSyntax != null && identifierSyntax.Identifier.ToString() == "GC" && method.Name.ToString() == "SuppressFinalize")
                         return;
                 }
             }

--- a/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
@@ -1,5 +1,6 @@
 ﻿using CodeCracker.CSharp.Usage;
 using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CodeCracker.Test.CSharp.Usage
@@ -55,6 +56,37 @@ namespace CodeCracker.Test.CSharp.Usage
             };
 
             await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task NoWarningIfClassImplementsDisposableCallsSuppressFinalizeAndCallsDisposeWithThis()
+        {
+            const string source = @"
+            public class MyType : System.IDisposable
+            {
+                public void Dispose()
+                {
+                    this.Dispose(true);
+                    GC.SuppressFinalize(this);
+                }
+            }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task NoWarningIfClassImplementsDisposableCallsSuppressFinalize()
+        {
+            const string source = @"
+            public class MyType : System.IDisposable
+            {
+                public void Dispose()
+                {
+                    GC.SuppressFinalize(this);
+                }
+            }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
 
 
@@ -206,8 +238,6 @@ namespace CodeCracker.Test.CSharp.Usage
 
             await VerifyCSharpFixAsync(source, fixtest, 0);
         }
-
-        
 
         [Fact]
         public async void WhenClassHasParametrizedDisposeMethod()

--- a/test/VisualBasic/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.vb
@@ -119,6 +119,41 @@ End Class
             Await VerifyBasicDiagnosticAsync(test, expected)
         End Function
 
+        <Fact>
+        Public Async Function NoWarningIfClassImplementsDisposableCallsSuppressFinalizeAndCallsDisposeWithMe() As Task
+            Const source = "
+Public Class MyType
+    Implements System.IDisposable
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Me.Dispose(True)
+        GC.SuppressFinalize(Me)
+    End Sub
+
+    Protected Overridable Sub Dispose(disposing As Boolean)
+    End Sub
+End Class"
+
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
+
+        <Fact>
+        Public Async Function NoWarningIfClassImplementsDisposableCallsSuppressFinalize() As Task
+            Const source = "
+Public Class MyType
+    Implements System.IDisposable
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        GC.SuppressFinalize(Me)
+    End Sub
+
+    Protected Overridable Sub Dispose(disposing As Boolean)
+    End Sub
+End Class"
+
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
+
         <Theory>
         <InlineData("Structure")>
         <InlineData("Class")>


### PR DESCRIPTION
Added an extra cast to both the C# and VB analyzers.  Also had to get the statements of this dispose for VB a bit differently.  It was always returning Nothing with the previous code because it was getting a declaration node, which does not include the statements, instead of a method block node that does contain the statements.