### PR TITLE
Fix #480

### DIFF
--- a/test/CSharp/CodeCracker.Test/Style/TernaryOperatorTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/TernaryOperatorTests.cs
@@ -225,6 +225,45 @@ namespace CodeCracker.Test.CSharp.Style
         }
 
         [Fact]
+        public async Task WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFix()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public void Foo()
+            {
+                var something = true;
+                int? a;
+                if (something)
+                {
+                    a = 1;
+                }
+                else
+                {
+                    a = null;
+                }
+            }
+        }
+    }";
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public void Foo()
+            {
+                var something = true;
+                int? a;
+                a = something ? 1 : (int?)null;
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
         public async Task WhenUsingIfAndElseWithAssignmentChangeToTernaryFixAll()
         {
             const string source = @"
@@ -391,6 +430,40 @@ namespace CodeCracker.Test.CSharp.Style
             {
                 var something = true;
                 return something ? 1 : 2;
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest, 0);
+        }
+
+        [Fact]
+        public async Task WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFix()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int? Foo()
+            {
+                var something = true;
+                if (something)
+                    return 1;
+                else
+                    return null;
+            }
+        }
+    }";
+
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public int? Foo()
+            {
+                var something = true;
+                return something ? 1 : (int?)null;
             }
         }
     }";


### PR DESCRIPTION
Fix #480 

Explicitly cast null to nullable type in conditional expression.

Extract common functionality of the 2 code fix providers into an abstract
base class.