### PR TITLE
Fix #468 by casting to nullable types as necessary.

### DIFF
--- a/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
@@ -178,6 +178,56 @@ Namespace ConsoleApplication1
 End Namespace"
         Await VerifyBasicFixAllAsync(New String() {sourceAssign, sourceAssign.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
     End Function
+
+    <Fact>
+    Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFix() As Task
+        Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim a As Integer?
+        If True Then
+            a = 1
+        Else
+            a = Nothing
+        End If
+    End Sub
+End Class"
+
+        Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim a As Integer?
+         a = If(True, 1, DirectCast(Nothing, Integer?))
+    End Sub
+End Class"
+
+        Await VerifyBasicFixAsync(source, fix)
+    End Function
+
+    <Fact>
+    Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFixAll() As Task
+        Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim a As Integer?
+        If True Then
+            a = 1
+        Else
+            a = Nothing
+        End If
+    End Sub
+End Class"
+
+        Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim a As Integer?
+         a = If(True, 1, DirectCast(Nothing, Integer?))
+    End Sub
+End Class"
+
+        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+    End Function
 End Class
 
 Public Class TernaryOperatorWithReturnTests
@@ -345,6 +395,52 @@ Namespace ConsoleApplication1
 End Namespace"
 
         Await VerifyBasicFixAllAsync(New String() {sourceReturn, sourceReturn.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+    End Function
+
+    <Fact>
+    Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFix() As Task
+        Const source = "
+Public Class MyType
+    Public Function Foo() As Integer?
+        If True Then
+            Return 1
+        Else
+            Return Nothing
+        End If
+    End Function
+End Class"
+
+        Const fix = "
+Public Class MyType
+    Public Function Foo() As Integer?
+        Return If(True, 1, DirectCast(Nothing, Integer?))
+    End Function
+End Class"
+
+        Await VerifyBasicFixAsync(source, fix)
+    End Function
+
+    <Fact>
+    Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFixAll() As Task
+        Const source = "
+Public Class MyType
+    Public Function Foo() As Integer?
+        If True Then
+            Return 1
+        Else
+            Return Nothing
+        End If
+    End Function
+End Class"
+
+        Const fix = "
+Public Class MyType
+    Public Function Foo() As Integer?
+        Return If(True, 1, DirectCast(Nothing, Integer?))
+    End Function
+End Class"
+
+        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
     End Function
 End Class
 


### PR DESCRIPTION
The correct code is being generated by the code fix provider, but I can not get the tests using `VerifyBasicFixAsync` to pass because it throws an error of
```
Fix introduced new compiler diagnostics:
Test0.vb(5) : error BC30002: Type 'Integer?' is not defined.
```
If I switch them to use `VerifyBasicFixAllAsync` they pass just fine.  Is there a known bug in `VerifyBasicFixAsync` or `VerifyBasicFixAllAsync`?