### PR TITLE
Fixes incorrect help links from Analyzers

### DIFF
--- a/src/CSharp/CodeCracker/Refactoring/IntroduceFieldFromConstructorAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Refactoring/IntroduceFieldFromConstructorAnalyzer.cs
@@ -24,7 +24,7 @@ namespace CodeCracker.CSharp.Refactoring
             DiagnosticSeverity.Hidden,
             isEnabledByDefault: true,
             description: Description,
-            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.TaskNameAsync));
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.IntroduceFieldFromConstructor));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/CSharp/CodeCracker/Style/RemoveAsyncFromMethodAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/RemoveAsyncFromMethodAnalyzer.cs
@@ -23,7 +23,7 @@ namespace CodeCracker.CSharp.Style
             DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: Description,
-            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.PropertyPrivateSet));
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.RemoveAsyncFromMethod));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/CSharp/CodeCracker/Usage/RethrowExceptionAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/RethrowExceptionAnalyzer.cs
@@ -25,7 +25,7 @@ namespace CodeCracker.CSharp.Usage
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: Description,
-            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.Regex));
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.RethrowException));
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/VisualBasic/CodeCracker/Refactoring/ParameterRefactoryAnalyzer.vb
+++ b/src/VisualBasic/CodeCracker/Refactoring/ParameterRefactoryAnalyzer.vb
@@ -19,7 +19,8 @@ Namespace Refactoring
         MessageFormat,
         Category,
         DiagnosticSeverity.Hidden,
-        isEnabledByDefault:=True
+        isEnabledByDefault:=True,
+        helpLinkUri:=HelpLink.ForDiagnostic(DiagnosticId.ParameterRefactory)
     )
 
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)


### PR DESCRIPTION
I noticed some analyzers had the wrong Help link Uri, so I fixed them.

Since this is a simple fix I used the `master` branch. If this should be on `vnext` just let me know and I'll redo.