### PR TITLE
Add PreferAnyToCountGreaterThanZero Analyzer, closes #490

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -56,6 +56,8 @@
     <Compile Include="Performance\StringBuilderInLoopAnalyzer.cs" />
     <Compile Include="Performance\UseStaticRegexIsMatchCodeFixProvider.cs" />
     <Compile Include="Refactoring\AddBracesToSwitchSectionsAnalyzer.cs" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroCodeFixProvider.cs" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroAnalyzer.cs" />
     <Compile Include="Refactoring\ExtractClassToFileCodeFixProvider.cs" />
     <Compile Include="Refactoring\AddBracesToSwitchSectionsCodeFixProvider.cs" />
     <Compile Include="Refactoring\AllowMembersOrderingAnalyzer.cs" />

--- a/src/CSharp/CodeCracker/Style/PreferAnyToCountGreaterThanZeroAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/PreferAnyToCountGreaterThanZeroAnalyzer.cs
@@ -1,0 +1,60 @@
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace CodeCracker.CSharp.Style
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PreferAnyToCountGreaterThanZeroAnalyzer : DiagnosticAnalyzer
+    {
+        internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.PreferAnyToCountGreaterThanZeroAnalyzer_Title), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat), Resources.ResourceManager, typeof(Resources));
+        internal const string Category = SupportedCategories.Style;
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId(),
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.PreferAnyToCountGreaterThanZero));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.GreaterThanExpression);
+
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.IsGenerated()) return;
+            var binExpression = context.Node as BinaryExpressionSyntax;
+            if (binExpression.IsNotKind(SyntaxKind.GreaterThanExpression)) return;
+            var rightSideExpression = binExpression.Right as LiteralExpressionSyntax;
+            if (rightSideExpression == null) return;
+            if (rightSideExpression.IsNotKind(SyntaxKind.NumericLiteralExpression)) return;
+            if (rightSideExpression.Token.ToString() != "0") return;
+            var memberExpression = binExpression.Left.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>().FirstOrDefault();
+            if (memberExpression == null) return;
+            if (memberExpression.Name.ToString() != "Count") return;
+            var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(memberExpression);
+            var namespaceName = memberSymbolInfo.Symbol.ContainingNamespace.ToString();
+            if (namespaceName != "System.Linq" && namespaceName != "System.Collections" && namespaceName != "System.Collections.Generic" ) return;
+            context.ReportDiagnostic(Diagnostic.Create(Rule, binExpression.GetLocation(), GetPredicateString(binExpression.Left)));
+        }
+
+        private static string GetPredicateString(ExpressionSyntax expression)
+        {
+            var predicateString = "";
+            if (expression is InvocationExpressionSyntax)
+            {
+                var arguments = ((InvocationExpressionSyntax)expression).ArgumentList;
+                predicateString = arguments?.Arguments == null ? "" : arguments.Arguments.Count > 0 ? "predicate" : "";
+            }
+            return predicateString;
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Style/PreferAnyToCountGreaterThanZeroCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/PreferAnyToCountGreaterThanZeroCodeFixProvider.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Formatting;
+using CodeCracker.Properties;
+
+namespace CodeCracker.CSharp.Style
+{
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PreferAnyToCountGreaterThanZeroCodeFixProvider)), Shared]
+    public class PreferAnyToCountGreaterThanZeroCodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId());
+        private static readonly SimpleNameSyntax anyName = (SimpleNameSyntax)SyntaxFactory.ParseName("Any");
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            context.RegisterCodeFix(CodeAction.Create(Resources.PreferAnyToCountGreaterThanZeroAnalyzer_Title, c => ConvertToAnyAsync(context.Document, diagnostic, c), nameof(PreferAnyToCountGreaterThanZeroCodeFixProvider)), diagnostic);
+            return Task.FromResult(0);
+        }
+
+        private static async Task<Document> ConvertToAnyAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = (CompilationUnitSyntax)await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            var greaterThanExpression = (BinaryExpressionSyntax)node;
+            var leftExpression = greaterThanExpression.Left;
+            var memberExpression = leftExpression.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>().FirstOrDefault();
+            var invocationExpression = leftExpression as InvocationExpressionSyntax;
+            var anyExpression = invocationExpression == null ? SyntaxFactory.InvocationExpression(memberExpression.WithName(anyName)) : SyntaxFactory.InvocationExpression(memberExpression.WithName(anyName), invocationExpression.ArgumentList)
+                .WithLeadingTrivia(greaterThanExpression.GetLeadingTrivia())
+                .WithTrailingTrivia(greaterThanExpression.GetTrailingTrivia());
+            var newRoot = root.ReplaceNode(greaterThanExpression, anyExpression);
+            newRoot = AddUsingSystemLinq(root, newRoot);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static CompilationUnitSyntax AddUsingSystemLinq(CompilationUnitSyntax root, CompilationUnitSyntax newRoot)
+        {
+            var isUsingSystemLinq = root.Usings.Any(u => u.Name.GetText().ToString() == "System.Linq");
+            if (!isUsingSystemLinq)
+                newRoot = newRoot.AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System.Linq")));
+            return newRoot;
+        }
+    }
+}

--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -82,6 +82,7 @@
         ChangeAllToAny = 92,
         SealMember = 94,
         ConsoleWriteLine = 95,
-        ExtractClassToFile = 96
+        ExtractClassToFile = 96,
+        PreferAnyToCountGreaterThanZero = 99
     }
 }

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -260,6 +260,24 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A call to &apos;Count({0}) &gt; 0&apos; can be changed to &apos;Any({0})&apos;.
+        /// </summary>
+        public static string PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat {
+            get {
+                return ResourceManager.GetString("PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer &apos;Any()&apos; to &apos;Count() &gt; 0&apos;.
+        /// </summary>
+        public static string PreferAnyToCountGreaterThanZeroAnalyzer_Title {
+            get {
+                return ResourceManager.GetString("PreferAnyToCountGreaterThanZeroAnalyzer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove async and return task directly..
         /// </summary>
         public static string ReturnTaskInsteadOfAwait_Description {

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -255,4 +255,10 @@
   <data name="SealMemberCodeFixProvider_MemberTitle" xml:space="preserve">
     <value>Seal member '{0}'</value>
   </data>
+  <data name="PreferAnyToCountGreaterThanZeroAnalyzer_Title" xml:space="preserve">
+    <value>Prefer 'Any()' to 'Count() &gt; 0'</value>
+  </data>
+  <data name="PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat" xml:space="preserve">
+    <value>A call to 'Count({0}) &gt; 0' can be changed to 'Any({0})'</value>
+  </data>
 </root>

--- a/src/VisualBasic/CodeCracker/CodeCracker.vbproj
+++ b/src/VisualBasic/CodeCracker/CodeCracker.vbproj
@@ -120,7 +120,9 @@
     <Compile Include="Refactoring\ParameterRefactoryCodeFixProvider.vb" />
     <Compile Include="Reliability\UseConfigureAwaitFalseAnalyzer.vb" />
     <Compile Include="Reliability\UseConfigureAwaitFalseCodeFixProvider.vb" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroAnalyzer.vb" />
     <Compile Include="Style\InterfaceNameAnalyzer.vb" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroCodeFixProvider.vb" />
     <Compile Include="Style\InterfaceNameCodeFixProvider.vb" />
     <Compile Include="Style\TernaryOperatorAnalyzer.vb" />
     <Compile Include="Style\TernaryOperatorCodeFixProviders.vb" />

--- a/src/VisualBasic/CodeCracker/Style/PreferAnyToCountGreaterThanZeroAnalyzer.vb
+++ b/src/VisualBasic/CodeCracker/Style/PreferAnyToCountGreaterThanZeroAnalyzer.vb
@@ -1,0 +1,63 @@
+﻿Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Style
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Public Class PreferAnyToCountGreaterThanZeroAnalyzer
+        Inherits DiagnosticAnalyzer
+
+        Friend Shared ReadOnly Title As LocalizableString = New LocalizableResourceString(NameOf(Properties.Resources.PreferAnyToCountGreaterThanZeroAnalyzer_Title), Properties.Resources.ResourceManager, GetType(Properties.Resources))
+        Friend Shared ReadOnly MessageFormat As LocalizableString = New LocalizableResourceString(NameOf(Properties.Resources.PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat), Properties.Resources.ResourceManager, GetType(Properties.Resources))
+        Friend Const Category = SupportedCategories.Style
+
+        Friend Shared Rule As New DiagnosticDescriptor(
+            DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId(),
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            isEnabledByDefault:=True,
+            helpLinkUri:=HelpLink.ForDiagnostic(DiagnosticId.PreferAnyToCountGreaterThanZero)
+        )
+
+        Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+            Get
+                Return ImmutableArray.Create(Rule)
+            End Get
+        End Property
+
+        Public Overrides Sub Initialize(context As AnalysisContext)
+            context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, SyntaxKind.GreaterThanExpression)
+        End Sub
+
+        Private Shared Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
+            If (context.IsGenerated()) Then Return
+            Dim binExpression = TryCast(context.Node, BinaryExpressionSyntax)
+            If Not binExpression.IsKind(SyntaxKind.GreaterThanExpression) Then Return
+            Dim rightSideExpression = TryCast(binExpression.Right, LiteralExpressionSyntax)
+            If rightSideExpression Is Nothing Then Return
+            If Not rightSideExpression.IsKind(SyntaxKind.NumericLiteralExpression) Then Return
+            If rightSideExpression.Token.ToString() <> "0" Then Return
+            Dim memberExpression = binExpression.Left.DescendantNodesAndSelf().OfType(Of MemberAccessExpressionSyntax).FirstOrDefault()
+            If memberExpression Is Nothing Then Return
+            If memberExpression.Name.ToString() <> "Count" Then Return
+            Dim memberSymbolInfo = context.SemanticModel.GetSymbolInfo(memberExpression)
+            Dim namespaceName = memberSymbolInfo.Symbol.ContainingNamespace.ToString()
+            If namespaceName <> "System.Linq" AndAlso namespaceName <> "System.Collections" AndAlso namespaceName <> "System.Collections.Generic" Then Return
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, binExpression.GetLocation(), GetPredicateString(binExpression.Left)))
+        End Sub
+
+        Private Shared Function GetPredicateString(expression As ExpressionSyntax) As String
+            Dim predicateString = ""
+            If TypeOf expression Is InvocationExpressionSyntax Then
+                Dim arguments = TryCast(expression, InvocationExpressionSyntax).ArgumentList
+                predicateString = If(arguments?.Arguments Is Nothing, "", If(arguments.Arguments.Count > 0, "predicate", ""))
+            End If
+            Return predicateString
+        End Function
+    End Class
+End Namespace

--- a/src/VisualBasic/CodeCracker/Style/PreferAnyToCountGreaterThanZeroCodeFixProvider.vb
+++ b/src/VisualBasic/CodeCracker/Style/PreferAnyToCountGreaterThanZeroCodeFixProvider.vb
@@ -1,0 +1,53 @@
+﻿Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeActions
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Rename
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports System.Collections.Immutable
+Imports System.Threading
+
+Namespace Style
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(PreferAnyToCountGreaterThanZeroCodeFixProvider)), Composition.Shared>
+    Public Class PreferAnyToCountGreaterThanZeroCodeFixProvider
+        Inherits CodeFixProvider
+
+        Public NotOverridable Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId())
+        Private Shared ReadOnly AnyName As SimpleNameSyntax = TryCast(SyntaxFactory.ParseName(NameOf(Any)), SimpleNameSyntax)
+
+        Public NotOverridable Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
+            Dim diagnostic = context.Diagnostics.First()
+            context.RegisterCodeFix(CodeAction.Create(Properties.Resources.PreferAnyToCountGreaterThanZeroAnalyzer_Title,
+                                              Function(c) ConvertToAnyAsync(context.Document, diagnostic, c), NameOf(PreferAnyToCountGreaterThanZeroCodeFixProvider)), diagnostic)
+            Return Task.FromResult(0)
+        End Function
+
+        Private Async Function ConvertToAnyAsync(document As Document, diagnostic As Diagnostic, cancellationToken As CancellationToken) As Task(Of Document)
+            Dim root = TryCast(Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False), CompilationUnitSyntax)
+            Dim node = root.FindNode(diagnostic.Location.SourceSpan)
+            Dim greaterThanExpression = TryCast(node, BinaryExpressionSyntax)
+            Dim leftExpression = greaterThanExpression.Left
+            Dim memberExpression = leftExpression.DescendantNodesAndSelf().OfType(Of MemberAccessExpressionSyntax)().FirstOrDefault()
+            Dim invocationExpression = TryCast(leftExpression, InvocationExpressionSyntax)
+            Dim argumentList = If(invocationExpression Is Nothing, SyntaxFactory.ArgumentList(), invocationExpression.ArgumentList)
+            Dim anyExpression = SyntaxFactory.InvocationExpression(memberExpression.WithName(AnyName), argumentList) _
+                .WithLeadingTrivia(greaterThanExpression.GetLeadingTrivia()) _
+                .WithTrailingTrivia(greaterThanExpression.GetTrailingTrivia())
+            Dim newRoot = root.ReplaceNode(greaterThanExpression, anyExpression)
+            newRoot = AddImportsSystemLinq(root, newRoot)
+            Return document.WithSyntaxRoot(newRoot)
+        End Function
+
+        Private Shared Function AddImportsSystemLinq(root As CompilationUnitSyntax, newRoot As CompilationUnitSyntax) As CompilationUnitSyntax
+            Dim isUsingSystemLinq = root.Imports.Any(Function(u) u.ImportsClauses.ToString() = "System.Linq")
+            If Not isUsingSystemLinq Then
+                Dim clause As ImportsClauseSyntax = SyntaxFactory.SimpleImportsClause(SyntaxFactory.ParseName("System.Linq").NormalizeWhitespace(elasticTrivia:=True))
+                Dim clauseList = SyntaxFactory.SeparatedList({clause})
+                Dim statement = SyntaxFactory.ImportsStatement(clauseList)
+                newRoot = newRoot.AddImports(statement)
+            End If
+
+            Return newRoot
+        End Function
+    End Class
+End Namespace

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Performance\ReturnTaskInsteadOfAwaitTests.cs" />
     <Compile Include="Performance\UseStaticRegexIsMatchTests.cs" />
     <Compile Include="Performance\StringBuilderInLoopTests.cs" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroTests.cs" />
     <Compile Include="Refactoring\ExtractClassToFileTests.cs" />
     <Compile Include="Refactoring\AddBracesToSwitchSectionsTests.cs" />
     <Compile Include="Refactoring\AllowMembersOrderingAnalyzerTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Style/PreferAnyToCountGreaterThanZeroTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/PreferAnyToCountGreaterThanZeroTests.cs
@@ -1,0 +1,169 @@
+﻿using CodeCracker.CSharp.Style;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Style
+{
+    public class PreferAnyToCountGreaterThanZeroTests : CodeFixVerifier<PreferAnyToCountGreaterThanZeroAnalyzer, PreferAnyToCountGreaterThanZeroCodeFixProvider>
+    {
+        private const string test = @"
+    using System;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            public async Task Foo()
+            {
+                var ints = new[] { 1, 2 };
+                var query = true && ints.Count() > 0 && true;
+            }
+        }
+    }";
+
+        [Fact]
+        public async Task CreatesDiagnosticsWhenUsingCountGreaterThanZero()
+        {
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId(),
+                Message = string.Format(PreferAnyToCountGreaterThanZeroAnalyzer.MessageFormat.ToString(), ""),
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 37) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task IgnoresCountWithoutZero()
+        {
+            const string testCountProp = @"
+    using System;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            public async Task Foo()
+            {
+                var list = new List<int>();
+                var query = list.Count() > 1;
+            }
+        }
+    }";
+            await VerifyCSharpHasNoDiagnosticsAsync(testCountProp);
+        }
+
+        [Fact]
+        public async Task ConvertsCountPropertyToAny()
+        {
+            const string testCountProp = @"
+    using System;
+    using System.Collections.Generic;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            public async Task Foo()
+            {
+                var list = new List<int>();
+                var query = list.Count > 0;
+            }
+        }
+    }";
+
+            const string fixTest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            public async Task Foo()
+            {
+                var list = new List<int>();
+                var query = list.Any();
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(testCountProp, fixTest);
+        }
+
+        [Fact]
+        public async Task ConvertsCountMethodToAny()
+        {
+
+            const string fixTest = @"
+    using System;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            public async Task Foo()
+            {
+                var ints = new[] { 1, 2 };
+                var query = true && ints.Any() && true;
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(test, fixTest);
+        }
+        
+
+        [Fact]
+        public async Task ConvertsToAnyWithPredicate()
+        {
+            const string testPredicate = @"
+    using System;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            class Bar
+            {
+                public bool A { get; set; }
+            }
+
+            public async Task Foo()
+            {
+                var bools = new[] { new Bar(), new Bar() };
+                var queryB = bools.Count(x => x.A) > 0;
+            }
+        }
+    }";
+
+            const string fixTest = @"
+    using System;
+    using System.Linq;
+
+    namespace ConsoleApplication1
+    {
+        class Program
+        {
+            class Bar
+            {
+                public bool A { get; set; }
+            }
+
+            public async Task Foo()
+            {
+                var bools = new[] { new Bar(), new Bar() };
+                var queryB = bools.Any(x => x.A);
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(testPredicate, fixTest);
+        }
+    }
+}

--- a/test/VisualBasic/CodeCracker.Test/CodeCracker.Test.vbproj
+++ b/test/VisualBasic/CodeCracker.Test/CodeCracker.Test.vbproj
@@ -174,6 +174,7 @@
     <Compile Include="Refactoring\ChangeAnyToAllTests.vb" />
     <Compile Include="Refactoring\ParameterRefactoryTests.vb" />
     <Compile Include="Reliability\UseConfigureAwaitFalseTests.vb" />
+    <Compile Include="Style\PreferAnyToCountGreaterThanZeroTests.vb" />
     <Compile Include="Style\InterfaceNameTests.vb" />
     <Compile Include="Style\TernaryOperatorTests.vb" />
     <Compile Include="Usage\DisposablesShouldCallSuppressFinalizeTests.vb" />

--- a/test/VisualBasic/CodeCracker.Test/Style/PreferAnyToCountGreaterThanZeroTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Style/PreferAnyToCountGreaterThanZeroTests.vb
@@ -1,0 +1,122 @@
+﻿Imports CodeCracker.VisualBasic.Style
+Imports Microsoft.CodeAnalysis
+Imports Xunit
+
+Namespace Style
+    Public Class PreferAnyToCountGreaterThanZeroTests
+        Inherits CodeFixVerifier(Of PreferAnyToCountGreaterThanZeroAnalyzer, PreferAnyToCountGreaterThanZeroCodeFixProvider)
+
+
+
+        Private Const Test As String = "Imports System.Linq
+    Module Module1
+
+        Sub Main()
+            Dim ints = {1, 2}
+            Dim query = True AndAlso ints.Count() > 0 AndAlso True
+        End Sub
+
+    End Module"
+
+        <Fact>
+        Public Async Function CreatesDiagnosticsWhenUsingCountGreaterThanZero() As Task
+            Dim expected = New DiagnosticResult With
+                {
+                    .Id = DiagnosticId.PreferAnyToCountGreaterThanZero.ToDiagnosticId(),
+                    .Message = String.Format(PreferAnyToCountGreaterThanZeroAnalyzer.MessageFormat.ToString(), ""),
+                    .Severity = DiagnosticSeverity.Info,
+                    .Locations = {New DiagnosticResultLocation("Test0.vb", 6, 38)}
+                }
+
+            Await VerifyBasicDiagnosticAsync(Test, expected)
+        End Function
+
+        <Fact>
+        Public Async Function IgnoresCountWithoutZero() As Task
+            Const TestCountProp As String = "Imports System.Linq
+    Module Module1
+
+        Sub Main()
+            Dim list = New List(Of Integer)(New Integer() {1, 2})
+            Dim query = list.Count() > 1
+        End Sub
+
+    End Module"
+
+            Await VerifyBasicHasNoDiagnosticsAsync(TestCountProp)
+        End Function
+
+        <Fact>
+        Public Async Function ConvertsCountPropertyToAny() As Task
+            Const TestCountProp As String = "Imports System.Collections.Generic
+Module Module1
+
+    Sub Main()
+        Dim list = New List(Of Integer)(New Integer() {1, 2})
+        Dim query = list.Count > 0
+    End Sub
+
+End Module"
+
+            Const FixTest As String = "Imports System.Collections.Generic
+Imports System.Linq
+
+Module Module1
+
+    Sub Main()
+        Dim list = New List(Of Integer)(New Integer() {1, 2})
+        Dim query = list.Any()
+    End Sub
+
+End Module"
+
+            Await VerifyBasicFixAsync(TestCountProp, FixTest)
+        End Function
+
+        <Fact>
+        Public Async Function ConvertsCountMethodToAny() As Task
+            Const FixTest As String = "Imports System.Linq
+    Module Module1
+
+        Sub Main()
+            Dim ints = {1, 2}
+            Dim query = True AndAlso ints.Any() AndAlso True
+        End Sub
+
+    End Module"
+
+            Await VerifyBasicFixAsync(Test, FixTest)
+        End Function
+
+        <Fact>
+        Public Async Function ConvertsToAnyWithPredicate() As Task
+            Const TestPredicate As String = "Imports System.Linq
+    Module Module1
+        Class Bar
+            Public A As Boolean
+        End Class
+
+        Sub Main()
+            Dim bools = {New Bar(), New Bar()}
+            Dim query = True AndAlso bools.Count(Function(x) x.A) > 0 AndAlso True
+        End Sub
+
+    End Module"
+
+            Const FixTest As String = "Imports System.Linq
+    Module Module1
+        Class Bar
+            Public A As Boolean
+        End Class
+
+        Sub Main()
+            Dim bools = {New Bar(), New Bar()}
+            Dim query = True AndAlso bools.Any(Function(x) x.A) AndAlso True
+        End Sub
+
+    End Module"
+
+            Await VerifyBasicFixAsync(TestPredicate, FixTest)
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Implemented this code fix for `Count() > 0` and `Count > 0` in C# and VB