### PR TITLE
CS0056 & CS0057 code-fix

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -42,6 +42,8 @@
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInfoProvider.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInMethodReturnType.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInFieldType.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInOperatorParameter.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInOperatorReturnType.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInPropertyType.cs" />
     <Compile Include="Design\MakeMethodStaticAnalyzer.cs" />
     <Compile Include="Design\MakeMethodStaticCodeFixProvider.cs" />

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
@@ -21,10 +21,21 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
         internal const string InconsistentAccessibilityInPropertyTypeCompilerErrorNumber = "CS0053";
         internal const string InconsistentAccessibilityInIndexerReturnTypeCompilerErrorNumber = "CS0054";
         internal const string InconsistentAccessibilityInIndexerParameterCompilerErrorNumber = "CS0055";
+        internal const string InconsistentAccessibilityInOperatorReturnTypeCompilerErrorNumber = "CS0056";
+        internal const string InconsistentAccessibilityInOperatorParameterCompilerErrorNumber = "CS0057";
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber, InconsistentAccessibilityInMethodParameterCompilerErrorNumber, InconsistentAccessibilityInFieldTypeCompilerErrorNumber, InconsistentAccessibilityInPropertyTypeCompilerErrorNumber, InconsistentAccessibilityInIndexerReturnTypeCompilerErrorNumber, InconsistentAccessibilityInIndexerParameterCompilerErrorNumber);
+        public override ImmutableArray<string> FixableDiagnosticIds
+            =>
+                ImmutableArray.Create(InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInMethodParameterCompilerErrorNumber,
+                    InconsistentAccessibilityInFieldTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInPropertyTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInIndexerReturnTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInIndexerParameterCompilerErrorNumber,
+                    InconsistentAccessibilityInOperatorReturnTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInOperatorParameterCompilerErrorNumber);
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -34,15 +45,29 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 
                 if (inconsistentAccessibilityInfo.TypeToChangeFound())
                 {
-                    var typeLocations = await FindTypeLocationsInSourceCodeAsync(context.Document, inconsistentAccessibilityInfo.TypeToChangeAccessibility, context.CancellationToken).ConfigureAwait(false);
+                    var typeLocations =
+                        await
+                            FindTypeLocationsInSourceCodeAsync(context.Document,
+                                inconsistentAccessibilityInfo.TypeToChangeAccessibility, context.CancellationToken)
+                                .ConfigureAwait(false);
 
                     if (typeLocations.Length == 1)
                     {
-                        context.RegisterCodeFix(CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage, c => ChangeTypeAccessibilityInDocumentAsync(context.Document.Project.Solution, inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations[0], c), nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
+                        context.RegisterCodeFix(
+                            CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
+                                c =>
+                                    ChangeTypeAccessibilityInDocumentAsync(context.Document.Project.Solution,
+                                        inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations[0], c),
+                                nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
                     }
                     else if (typeLocations.Length > 1)
                     {
-                        context.RegisterCodeFix(CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage, c => ChangeTypeAccessibilityInSolutionAsync(context.Document.Project.Solution, inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations, c), nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
+                        context.RegisterCodeFix(
+                            CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
+                                c =>
+                                    ChangeTypeAccessibilityInSolutionAsync(context.Document.Project.Solution,
+                                        inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations, c),
+                                nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
                     }
                 }
             }
@@ -71,6 +96,12 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
                     break;
                 case InconsistentAccessibilityInIndexerParameterCompilerErrorNumber:
                     inconsistentAccessibilityProvider = new InconsistentAccessibilityInIndexerParameter();
+                    break;
+                case InconsistentAccessibilityInOperatorReturnTypeCompilerErrorNumber:
+                    inconsistentAccessibilityProvider = new InconsistentAccessibilityInOperatorReturnType();
+                    break;
+                case InconsistentAccessibilityInOperatorParameterCompilerErrorNumber:
+                    inconsistentAccessibilityProvider = new InconsistentAccessibilityInOperatorParameter();
                     break;
             }
 

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInOperatorParameter.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInOperatorParameter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public class InconsistentAccessibilityInOperatorParameter : InconsistentAccessibilityInfoProvider
+    {
+        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInOperatorParameter_Title), Resources.ResourceManager, typeof(Resources));
+
+        public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var result = new InconsistentAccessibilityInfo();
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nodeWhenErrorOccured = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
+            var operatorThatRaisedError =
+                nodeWhenErrorOccured.FirstAncestorOrSelfOfType(
+                    typeof(OperatorDeclarationSyntax),
+                    typeof(ConversionOperatorDeclarationSyntax)) as BaseMethodDeclarationSyntax;
+
+            if (operatorThatRaisedError != null)
+            {
+                var parameterType = ExtractParameterTypeFromDiagnosticMessage(diagnostic);
+
+                result.TypeToChangeAccessibility = operatorThatRaisedError.ParameterList.Parameters.FindTypeInParametersList(parameterType);
+                result.CodeActionMessage = string.Format(CodeActionMessage.ToString(), parameterType,
+                    operatorThatRaisedError.GetOperatorName());
+                result.NewAccessibilityModifiers = operatorThatRaisedError.Modifiers.CloneAccessibilityModifiers();
+            }
+
+            return result;
+        }
+
+        private static string ExtractParameterTypeFromDiagnosticMessage(Diagnostic diagnostic) =>
+            Regex.Match(diagnostic.GetMessage(CultureInfo.InvariantCulture),
+                "Inconsistent accessibility: parameter type '(.*)' is less accessible than operator '(.*)'").Groups[1]
+                .Value;
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInOperatorReturnType.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInOperatorReturnType.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class InconsistentAccessibilityInOperatorReturnType : InconsistentAccessibilityInfoProvider
+    {
+        private static readonly LocalizableString CodeActionMessage = new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInOperatorReturnType_Title), Resources.ResourceManager, typeof(Resources));
+
+        public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var result = new InconsistentAccessibilityInfo();
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nodeWhenErrorOccured = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
+            var operatorThatRaisedError =
+                nodeWhenErrorOccured.FirstAncestorOrSelfOfType(
+                    typeof (OperatorDeclarationSyntax),
+                    typeof (ConversionOperatorDeclarationSyntax)) as BaseMethodDeclarationSyntax;
+
+            if (operatorThatRaisedError != null)
+            {
+                var type = GetTypeFromOperator(operatorThatRaisedError);
+                result.TypeToChangeAccessibility = type;
+                result.CodeActionMessage = string.Format(CodeActionMessage.ToString(), type, operatorThatRaisedError.GetOperatorName());
+                result.NewAccessibilityModifiers = operatorThatRaisedError.Modifiers.CloneAccessibilityModifiers();
+            }
+
+            return result;
+        }
+
+        private static TypeSyntax GetTypeFromOperator(BaseMethodDeclarationSyntax operatorSyntax)
+        {
+            var result = default(TypeSyntax);
+            switch (operatorSyntax.Kind())
+            {
+                case SyntaxKind.OperatorDeclaration:
+                    result = ((OperatorDeclarationSyntax) operatorSyntax).ReturnType;
+                    break;
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    result = ((ConversionOperatorDeclarationSyntax) operatorSyntax).Type;
+                    break;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Extensions/CSharpAnalyzerExtensions.cs
+++ b/src/CSharp/CodeCracker/Extensions/CSharpAnalyzerExtensions.cs
@@ -473,9 +473,35 @@ namespace CodeCracker
 
         public static SyntaxTokenList CloneAccessibilityModifiers(this SyntaxTokenList modifiers)
         {
-            var accessibilityModifiers = modifiers.Where(token => token.IsKind(SyntaxKind.PublicKeyword) || token.IsKind(SyntaxKind.ProtectedKeyword) || token.IsKind(SyntaxKind.InternalKeyword) || token.IsKind(SyntaxKind.PrivateKeyword)).Select(token => SyntaxFactory.Token(token.Kind()));
+            var accessibilityModifiers =
+                modifiers.Where(
+                    token =>
+                        token.IsKind(SyntaxKind.PublicKeyword) || token.IsKind(SyntaxKind.ProtectedKeyword) ||
+                        token.IsKind(SyntaxKind.InternalKeyword) || token.IsKind(SyntaxKind.PrivateKeyword))
+                    .Select(token => SyntaxFactory.Token(token.Kind()));
 
             return SyntaxFactory.TokenList(accessibilityModifiers.EnsureProtectedBeforeInternal());
+        }
+
+        public static string GetOperatorName(this BaseMethodDeclarationSyntax operatorSyntax)
+        {
+            switch (operatorSyntax.Kind())
+            {
+                case SyntaxKind.OperatorDeclaration:
+                    var operatorDeclaration = (OperatorDeclarationSyntax)operatorSyntax;
+                    return $"{operatorSyntax.GetTypeDeclaration().Identifier.ValueText}.{operatorDeclaration.OperatorKeyword} {operatorDeclaration.OperatorToken}{operatorDeclaration.ParameterList}";
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    var conversionOperatorDeclaration = (ConversionOperatorDeclarationSyntax)operatorSyntax;
+                    return $"{operatorSyntax.GetTypeDeclaration().Identifier.ValueText}.{conversionOperatorDeclaration.ImplicitOrExplicitKeyword} {conversionOperatorDeclaration.Type}{conversionOperatorDeclaration.ParameterList}";
+                default:
+                    throw new InvalidOperationException("Passed MethodDeclaration is not any kind of OperatorDeclaration");
+            }
+        }
+
+        public static TypeDeclarationSyntax GetTypeDeclaration(this BaseMethodDeclarationSyntax methodSyntax)
+        {
+            return methodSyntax.FirstAncestorOfType(typeof(ClassDeclarationSyntax),
+                typeof(StructDeclarationSyntax)) as TypeDeclarationSyntax;
         }
 
         public static bool IsLoopStatement(this SyntaxNode note) => note.IsAnyKind(SyntaxKind.ForEachStatement, SyntaxKind.ForStatement, SyntaxKind.WhileStatement, SyntaxKind.DoStatement);

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -179,6 +179,24 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change parameter type &apos;{0}&apos; accessibility to be as accessible as operator &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInOperatorParameter_Title {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInOperatorParameter_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change return type &apos;{0}&apos; accessibility to be as accessible as operator &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInOperatorReturnType_Title {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInOperatorReturnType_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change property type &apos;{0}&apos; accessibility to be as accessible as property &apos;{1}&apos;.
         /// </summary>
         public static string InconsistentAccessibilityInPropertyType_Title {

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -255,4 +255,10 @@
   <data name="SealMemberCodeFixProvider_MemberTitle" xml:space="preserve">
     <value>Seal member '{0}'</value>
   </data>
+  <data name="InconsistentAccessibilityInOperatorReturnType_Title" xml:space="preserve">
+    <value>Change return type '{0}' accessibility to be as accessible as operator '{1}'</value>
+  </data>
+  <data name="InconsistentAccessibilityInOperatorParameter_Title" xml:space="preserve">
+    <value>Change parameter type '{0}' accessibility to be as accessible as operator '{1}'</value>
+  </data>
 </root>

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -210,6 +210,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Design\InconsistentAccessibilityTests.FieldPropertyType.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.OperatorReturnType.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.OperatorParameter.cs" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorParameter.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorParameter.cs
@@ -1,0 +1,72 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ShouldFixInconsistentAccessibilityInBinaryOperatorParameterAsync()
+        {
+            var testCode = @"public class Money
+    {
+        public static string operator +(Money m, SomeClass s)
+        {
+            return string.Empty;
+        }
+    }
+
+    internal class SomeClass
+    {
+
+    }";
+
+            var fixedCode = @"public class Money
+    {
+        public static string operator +(Money m, SomeClass s)
+        {
+            return string.Empty;
+        }
+    }
+
+    public class SomeClass
+    {
+
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixInconsistentAccessibilityInConversionOperatorParameterAsync()
+        {
+            var testCode = @"public class Money
+    {
+        public static explicit operator Money(SomeClass s)
+        {
+            return new Money();
+        }
+    }
+
+    internal class SomeClass
+    {
+
+    }";
+
+            var fixedCode = @"public class Money
+    {
+        public static explicit operator Money(SomeClass s)
+        {
+            return new Money();
+        }
+    }
+
+    public class SomeClass
+    {
+
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorReturnType.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorReturnType.cs
@@ -1,0 +1,202 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
+    {
+        [Theory]
+        [InlineData("++")]
+        [InlineData("--")]
+        [InlineData("~")]
+        [InlineData("+")]
+        [InlineData("-")]
+        [InlineData("!")]
+        public async Task ShouldFixInconsistentAccessibilityInUnaryOperatorAsync(string unaryOperator)
+        {
+            var testCode = @"public class Base
+    {
+        public static Derived operator " + unaryOperator + @"(Base m)
+        {
+            return new Derived();
+        }
+    }
+
+    internal class Derived : Base
+    {
+
+    }";
+
+            var fixedCode = @"public class Base
+    {
+        public static Derived operator " + unaryOperator + @"(Base m)
+        {
+            return new Derived();
+        }
+    }
+
+    public class Derived : Base
+    {
+
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("+")]
+        [InlineData("-")]
+        [InlineData("*")]
+        [InlineData("/")]
+        [InlineData("%")]
+        [InlineData("&")]
+        [InlineData("|")]
+        [InlineData("^")]
+        public async Task ShouldFixInconsistentAccessibilityInBinaryOperatorAsync(string binaryOperator)
+        {
+            var testCode = @"public class Base
+    {
+        public static Derived operator " + binaryOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+    }
+
+    internal class Derived : Base
+    {
+        
+    }";
+
+            var fixedCode = @"public class Base
+    {
+        public static Derived operator " + binaryOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+    }
+
+    public class Derived : Base
+    {
+        
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("==", "!=")]
+        [InlineData("<", ">")]
+        [InlineData(">=", "<=")]
+        public async Task ShouldFixInconsistentAccessibilityInPairwiseBinaryOperatorAsync(string binaryOperator,
+            string matchingOperator)
+        {
+            var testCode = @"public class Base
+    {
+        public static Derived operator " + binaryOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+
+        public static Derived operator " + matchingOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+    }
+
+    internal class Derived : Base
+    {
+        
+    }";
+
+            var fixedCode = @"public class Base
+    {
+        public static Derived operator " + binaryOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+
+        public static Derived operator " + matchingOperator + @"(Base m1, Base m2)
+        {
+            return new Derived();
+        }
+    }
+
+    public class Derived : Base
+    {
+        
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("<<")]
+        [InlineData(">>")]
+        public async Task ShouldFixInconsistentAccessibilityInShifBinaryOperatorAsync(string shiftBinaryOperator)
+        {
+            var testCode = @"public class Base
+    {
+        public static Derived operator " + shiftBinaryOperator + @"(Base m1, int m2)
+        {
+            return new Derived();
+        }
+    }
+
+    internal class Derived : Base
+    {
+        
+    }";
+
+            var fixedCode = @"public class Base
+    {
+        public static Derived operator " + shiftBinaryOperator + @"(Base m1, int m2)
+        {
+            return new Derived();
+        }
+    }
+
+    public class Derived : Base
+    {
+        
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixInconsistentAccessibilityInConversionOperatorAsync()
+        {
+            var testCode = @"public class Money
+    {
+        public static implicit operator SomeClass(Money m)
+        {
+            return new SomeClass();
+        }
+    }
+
+    internal class SomeClass
+    {
+
+    }";
+
+            var fixedCode = @"public class Money
+    {
+        public static implicit operator SomeClass(Money m)
+        {
+            return new SomeClass();
+        }
+    }
+
+    public class SomeClass
+    {
+        
+    }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
Fixes `CS0056` and `CS0057` in #381.

Implementation with tests for [CS0056](https://msdn.microsoft.com/en-us/library/7zdw9dt0%28v=vs.90%29.aspx) and [CS0057](https://msdn.microsoft.com/en-us/library/1he6k2zs%28v=vs.90%29.aspx) compiler error numbers.

@giggio, please take a look because it's been a while since I made a pull request to code-cracker. Let me know if anything. 

Thanks :+1: !