### PR TITLE
CS0058 & CS0059 code-fix

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -34,7 +34,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Design\InconsistentAccessibility\AccessibilityDomainChecker.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityCodeFix.cs" />
+    <Compile Include="Design\InconsistentAccessibility\IInconsistentAccessibilityCodeFix.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityCodeFixProvider.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInDelegateParameterType.cs" />
+    <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInDelegateReturnType.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInfo.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInIndexerParameter.cs" />
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInIndexerReturnType.cs" />

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/AccessibilityDomainChecker.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/AccessibilityDomainChecker.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class AccessibilityDomainChecker : IInconsistentAccessibilityCodeFix
+    {
+        private readonly IInconsistentAccessibilityCodeFix codeFix;
+
+        public AccessibilityDomainChecker(IInconsistentAccessibilityCodeFix codeFix)
+        {
+            if (codeFix == null)
+            {
+                throw new ArgumentNullException(nameof(codeFix));
+            }
+            this.codeFix = codeFix;
+        }
+
+        public async Task FixAsync(CodeFixContext context, Diagnostic diagnostic,
+            InconsistentAccessibilityInfo info)
+        {
+            var typeSymbol =
+                await
+                    FindTypeSymbolForAsync(context.Document, info.TypeToChangeAccessibility, context.CancellationToken);
+
+            if (typeSymbol == null || IsTypeFromMetada(typeSymbol))
+            {
+                return;
+            }
+
+            if (ReasonForInconsistentAccessibilityIsInAccessibilityDomain(typeSymbol, info.NewAccessibilityModifiers))
+            {
+                foreach (
+                    var inconsistentAccessibilityReason in
+                        FindInconsistentAccessibilityReasons(typeSymbol, info.NewAccessibilityModifiers))
+                {
+                    var finder = new IdentifierNameFinder(inconsistentAccessibilityReason);
+                    info.TypeToChangeAccessibility.Accept(finder);
+
+                    var newInfo = new InconsistentAccessibilityInfo
+                    {
+                        CodeActionMessage = info.CodeActionMessage,
+                        NewAccessibilityModifiers = info.NewAccessibilityModifiers,
+                        TypeToChangeAccessibility = finder.Result
+                    };
+
+                    await codeFix.FixAsync(context, diagnostic, newInfo);
+                }
+            }
+            else
+            {
+                await codeFix.FixAsync(context, diagnostic, info);
+            }
+        }
+
+        private static bool IsTypeFromMetada(ISymbol typeSymbol) => typeSymbol.Locations.All(l => l.IsInMetadata);
+
+        private static async Task<ISymbol> FindTypeSymbolForAsync(Document document, TypeSyntax type, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var typeSymbol = semanticModel.GetSymbolInfo(type, cancellationToken).Symbol;
+
+            return typeSymbol;
+        }
+
+        private static IEnumerable<string> FindInconsistentAccessibilityReasons(ISymbol typeSymbol, SyntaxTokenList accessibilityModifiers)
+        {
+            var symbolToCheck = typeSymbol;
+            while (symbolToCheck != null)
+            {
+                if (IsInconsistentAccessibilityReason(symbolToCheck, accessibilityModifiers))
+                {
+                    yield return symbolToCheck.Name;
+                }
+                symbolToCheck = symbolToCheck.ContainingType;
+            }
+        }
+
+        private static bool IsInconsistentAccessibilityReason(ISymbol typeSymbol, SyntaxTokenList accessibilityModifiers)
+        {
+            return typeSymbol.DeclaredAccessibility != ToSymbolAccessibility(accessibilityModifiers);
+        }
+
+        private static bool ReasonForInconsistentAccessibilityIsInAccessibilityDomain(ISymbol typeSymbol,
+            SyntaxTokenList accessibilityModifiers)
+            =>
+                typeSymbol.DeclaredAccessibility == ToSymbolAccessibility(accessibilityModifiers) &&
+                typeSymbol.ContainingType != null;
+
+        private static Accessibility ToSymbolAccessibility(SyntaxTokenList accessibilityModifiers)
+        {
+            if (accessibilityModifiers.Count > 1)
+            {
+                return Accessibility.ProtectedAndInternal;
+            }
+
+            return MapToAccessibility(accessibilityModifiers.First().Kind());
+        }
+
+        private static Accessibility MapToAccessibility(SyntaxKind syntaxKind)
+        {
+            switch (syntaxKind)
+            {
+                case SyntaxKind.PublicKeyword:
+                    return Accessibility.Public;
+                case SyntaxKind.ProtectedKeyword:
+                    return Accessibility.Protected;
+                case SyntaxKind.InternalKeyword:
+                    return Accessibility.Friend;
+            }
+
+            return Accessibility.NotApplicable;
+        }
+
+        private class IdentifierNameFinder : CSharpSyntaxWalker
+        {
+            private readonly string identifierNameToFind;
+
+            public IdentifierNameFinder(string identifierNameToFind)
+            {
+                if (string.IsNullOrEmpty(identifierNameToFind))
+                {
+                    throw new ArgumentNullException(nameof(identifierNameToFind));
+                }
+                this.identifierNameToFind = identifierNameToFind;
+            }
+
+            public NameSyntax Result { get; private set; }
+
+            public override void VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                if (Result == null &&
+                    string.Equals(identifierNameToFind, node.Identifier.ValueText, StringComparison.Ordinal))
+                {
+                    Result = node;
+                    return;
+                }
+
+                base.VisitIdentifierName(node);
+            }
+
+            public override void VisitQualifiedName(QualifiedNameSyntax node)
+            {
+                if (Result == null &&
+                    string.Equals(node.Right.Identifier.Text, identifierNameToFind, StringComparison.Ordinal))
+                {
+                    Result = node;
+                    return;
+                }
+                base.VisitQualifiedName(node);
+            }
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/IInconsistentAccessibilityCodeFix.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/IInconsistentAccessibilityCodeFix.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public interface IInconsistentAccessibilityCodeFix
+    {
+        Task FixAsync(CodeFixContext context, Diagnostic diagnostic, InconsistentAccessibilityInfo info);
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFix.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFix.cs
@@ -1,0 +1,193 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class InconsistentAccessibilityCodeFix : IInconsistentAccessibilityCodeFix
+    {
+        public async Task FixAsync(CodeFixContext context, Diagnostic diagnostic,
+            InconsistentAccessibilityInfo inconsistentAccessibilityInfo)
+        {
+            if (inconsistentAccessibilityInfo.TypeToChangeFound())
+            {
+                var typeLocations =
+                    await FindTypeLocationsAsync(context.Document,
+                        inconsistentAccessibilityInfo.TypeToChangeAccessibility, context.CancellationToken)
+                        .ConfigureAwait(false);
+
+                if (typeLocations.Length == 1)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
+                            c => ChangeTypeAccessibilityInDocumentAsync(context.Document.Project.Solution,
+                                inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations[0], c),
+                            nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
+                }
+                else if (typeLocations.Length > 1)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
+                            c => ChangeTypeAccessibilityInSolutionAsync(context.Document.Project.Solution,
+                                inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations, c),
+                            nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
+                }
+            }
+        }
+
+        private static async Task<Location[]> FindTypeLocationsAsync(Document document, TypeSyntax type, CancellationToken cancellationToken)
+        {
+            var result = new Location[] { };
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var typeSymbol = semanticModel.GetSymbolInfo(type, cancellationToken).Symbol;
+
+            if (typeSymbol != null)
+            {
+                result = typeSymbol.Locations.Where(location => location.IsInSource).ToArray();
+            }
+
+            return result;
+        }
+
+        private static async Task<Document> ChangeTypeAccessibilityInDocumentAsync(Solution solution, SyntaxTokenList newAccessibilityModifiers, Location typeLocation, CancellationToken cancellationToken)
+        {
+            var document = solution.GetDocument(typeLocation.SourceTree);
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var newRoot = ChangeTypeAccessibilityInSyntaxRoot(syntaxRoot, newAccessibilityModifiers, typeLocation);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static async Task<Solution> ChangeTypeAccessibilityInSolutionAsync(Solution solution, SyntaxTokenList newAccessibilityModifiers, IEnumerable<Location> typeLocations, CancellationToken cancellationToken)
+        {
+            var updatedSolution = solution;
+            var typeLocationsGroupedByDocument = typeLocations.GroupBy(location => solution.GetDocument(location.SourceTree));
+
+            foreach (var typeLocationsWithinDocument in typeLocationsGroupedByDocument)
+            {
+                var document = typeLocationsWithinDocument.Key;
+                var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var newRoot = ChangeTypesAccessibilityInSyntaxRoot(syntaxRoot, newAccessibilityModifiers, typeLocationsWithinDocument);
+                updatedSolution = updatedSolution.WithDocumentSyntaxRoot(document.Id, newRoot);
+            }
+
+            return updatedSolution;
+        }
+
+        private static SyntaxNode ChangeTypeAccessibilityInSyntaxRoot(SyntaxNode syntaxRoot, SyntaxTokenList newAccessibilityModifiers, Location typeLocation)
+        {
+            var declaration = (MemberDeclarationSyntax)syntaxRoot.FindNode(typeLocation.SourceSpan);
+
+            var newDeclaration = ChangeAccessibilityModifiersInDeclaration(declaration, newAccessibilityModifiers);
+
+            return syntaxRoot.ReplaceNode(declaration, newDeclaration);
+        }
+
+        private static SyntaxNode ChangeTypesAccessibilityInSyntaxRoot(SyntaxNode syntaxRoot, SyntaxTokenList newAccessibilityModifiers, IEnumerable<Location> typeLocations)
+        {
+            var declarations = typeLocations.Select(typeLocation => (MemberDeclarationSyntax)syntaxRoot.FindNode(typeLocation.SourceSpan)).ToList();
+            var newDeclarations = new Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax>();
+
+            foreach (var declaration in declarations)
+            {
+                newDeclarations.Add(declaration, ChangeAccessibilityModifiersInDeclaration(declaration, newAccessibilityModifiers));
+            }
+
+            return syntaxRoot.ReplaceNodes(declarations, (original, rewritten) => newDeclarations[original]);
+        }
+
+        private static MemberDeclarationSyntax ChangeAccessibilityModifiersInDeclaration(MemberDeclarationSyntax declaration, SyntaxTokenList newAccessibilityModifiers)
+        {
+            var newDeclaration = declaration;
+
+            var actualTypeAccessibilityModifiers = GetAccessibilityModifiersFromMember(declaration);
+            var hasAccessibilityModifiers = actualTypeAccessibilityModifiers.Any();
+
+            var leadingTrivias = default(SyntaxTriviaList);
+            var trailingTrivias = default(SyntaxTriviaList);
+            if (!hasAccessibilityModifiers)
+            {
+                var modifiers = declaration.GetModifiers();
+                if (modifiers.Any())
+                {
+                    var firstModifier = modifiers.First();
+                    leadingTrivias = firstModifier.LeadingTrivia;
+                    newDeclaration = RemoveLeadingTriviasFromFirstDeclarationModifier(declaration, modifiers, firstModifier);
+                }
+                else
+                {
+                    leadingTrivias = declaration.GetLeadingTrivia();
+                    newDeclaration = RemoveLeadingTriviasFromDeclaration(declaration);
+                }
+                trailingTrivias = SyntaxFactory.TriviaList(SyntaxFactory.Space);
+            }
+            else
+            {
+                leadingTrivias = actualTypeAccessibilityModifiers.First().LeadingTrivia;
+                trailingTrivias = GetAllTriviasAfterFirstModifier(actualTypeAccessibilityModifiers);
+            }
+
+            newAccessibilityModifiers = MergeActualTriviasIntoNewAccessibilityModifiers(newAccessibilityModifiers, leadingTrivias, trailingTrivias);
+
+            newDeclaration = ReplaceDeclarationModifiers(newDeclaration, actualTypeAccessibilityModifiers.ToList(), newAccessibilityModifiers);
+
+            return newDeclaration;
+        }
+
+        private static IEnumerable<SyntaxToken> GetAccessibilityModifiersFromMember(MemberDeclarationSyntax member) => member.GetModifiers().Where(token => token.IsKind(SyntaxKind.PublicKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword, SyntaxKind.PrivateKeyword));
+
+        private static MemberDeclarationSyntax RemoveLeadingTriviasFromFirstDeclarationModifier(MemberDeclarationSyntax declaration, SyntaxTokenList modifiers, SyntaxToken modifier) => declaration.WithModifiers(modifiers.Replace(modifier, modifier.WithLeadingTrivia(default(SyntaxTriviaList))));
+
+        private static MemberDeclarationSyntax RemoveLeadingTriviasFromDeclaration(MemberDeclarationSyntax declaration) => declaration.WithoutLeadingTrivia();
+
+        private static SyntaxTriviaList GetAllTriviasAfterFirstModifier(IEnumerable<SyntaxToken> modifiers) => SyntaxFactory.TriviaList(modifiers.Skip(1).SelectMany(token => token.LeadingTrivia).Union(modifiers.SelectMany(token => token.TrailingTrivia)));
+
+        private static MemberDeclarationSyntax ReplaceDeclarationModifiers(MemberDeclarationSyntax declaration, List<SyntaxToken> oldAccessibilityModifiers, SyntaxTokenList newAccessibilityModifiers)
+        {
+            var result = declaration;
+            var replacedModifiers = declaration.GetModifiers();
+
+            if (oldAccessibilityModifiers.Count == 0)
+            {
+                replacedModifiers = replacedModifiers.InsertRange(0, newAccessibilityModifiers);
+            }
+            else if (oldAccessibilityModifiers.Count == 1)
+            {
+                replacedModifiers = replacedModifiers.ReplaceRange(oldAccessibilityModifiers[0], newAccessibilityModifiers);
+            }
+            else if (oldAccessibilityModifiers.Count == 2)
+            {
+                replacedModifiers = replacedModifiers.ReplaceRange(oldAccessibilityModifiers[0], newAccessibilityModifiers);
+                replacedModifiers = replacedModifiers.Remove(replacedModifiers.SingleOrDefault(token => token.IsKind(oldAccessibilityModifiers[1].Kind())));
+            }
+
+            result = declaration.WithModifiers(replacedModifiers);
+
+            return result;
+        }
+
+        private static SyntaxTokenList MergeActualTriviasIntoNewAccessibilityModifiers(SyntaxTokenList modifiers, SyntaxTriviaList leadingTrivias, SyntaxTriviaList trailingTrivias)
+        {
+            if (modifiers.Count == 1)
+            {
+                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(leadingTrivias).WithTrailingTrivia(trailingTrivias));
+            }
+            else if (modifiers.Count == 2)
+            {
+                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(leadingTrivias));
+                modifiers = modifiers.Replace(modifiers[1], modifiers[1].WithTrailingTrivia(trailingTrivias));
+            }
+
+            return modifiers;
+        }
+    }
+
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityCodeFixProvider.cs
@@ -1,14 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 
 namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 {
@@ -23,55 +18,27 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
         internal const string InconsistentAccessibilityInIndexerParameterCompilerErrorNumber = "CS0055";
         internal const string InconsistentAccessibilityInOperatorReturnTypeCompilerErrorNumber = "CS0056";
         internal const string InconsistentAccessibilityInOperatorParameterCompilerErrorNumber = "CS0057";
+        internal const string InconsistentAccessibilityInDelegateReturnTypeCompilerErrorNumber = "CS0058";
+        internal const string InconsistentAccessibilityInDelegateParameterTypeCompilerErrorNumber = "CS0059";
+
+        private readonly IInconsistentAccessibilityCodeFix inconsistentAccessibilityCodeFix =
+            new AccessibilityDomainChecker(new InconsistentAccessibilityCodeFix());
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
         public override ImmutableArray<string> FixableDiagnosticIds
             =>
-                ImmutableArray.Create(InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber,
+                ImmutableArray.Create(
+                    InconsistentAccessibilityInMethodReturnTypeCompilerErrorNumber,
                     InconsistentAccessibilityInMethodParameterCompilerErrorNumber,
                     InconsistentAccessibilityInFieldTypeCompilerErrorNumber,
                     InconsistentAccessibilityInPropertyTypeCompilerErrorNumber,
                     InconsistentAccessibilityInIndexerReturnTypeCompilerErrorNumber,
                     InconsistentAccessibilityInIndexerParameterCompilerErrorNumber,
                     InconsistentAccessibilityInOperatorReturnTypeCompilerErrorNumber,
-                    InconsistentAccessibilityInOperatorParameterCompilerErrorNumber);
-
-        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-        {
-            foreach (var diagnostic in context.Diagnostics)
-            {
-                var inconsistentAccessibilityInfo = await GetInconsistentAccessibilityInfoAsync(context.Document, diagnostic, context.CancellationToken).ConfigureAwait(false);
-
-                if (inconsistentAccessibilityInfo.TypeToChangeFound())
-                {
-                    var typeLocations =
-                        await
-                            FindTypeLocationsInSourceCodeAsync(context.Document,
-                                inconsistentAccessibilityInfo.TypeToChangeAccessibility, context.CancellationToken)
-                                .ConfigureAwait(false);
-
-                    if (typeLocations.Length == 1)
-                    {
-                        context.RegisterCodeFix(
-                            CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
-                                c =>
-                                    ChangeTypeAccessibilityInDocumentAsync(context.Document.Project.Solution,
-                                        inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations[0], c),
-                                nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
-                    }
-                    else if (typeLocations.Length > 1)
-                    {
-                        context.RegisterCodeFix(
-                            CodeAction.Create(inconsistentAccessibilityInfo.CodeActionMessage,
-                                c =>
-                                    ChangeTypeAccessibilityInSolutionAsync(context.Document.Project.Solution,
-                                        inconsistentAccessibilityInfo.NewAccessibilityModifiers, typeLocations, c),
-                                nameof(InconsistentAccessibilityCodeFixProvider)), diagnostic);
-                    }
-                }
-            }
-        }
+                    InconsistentAccessibilityInOperatorParameterCompilerErrorNumber,
+                    InconsistentAccessibilityInDelegateReturnTypeCompilerErrorNumber,
+                    InconsistentAccessibilityInDelegateParameterTypeCompilerErrorNumber);
 
         private static async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
@@ -103,157 +70,25 @@ namespace CodeCracker.CSharp.Design.InconsistentAccessibility
                 case InconsistentAccessibilityInOperatorParameterCompilerErrorNumber:
                     inconsistentAccessibilityProvider = new InconsistentAccessibilityInOperatorParameter();
                     break;
+                case InconsistentAccessibilityInDelegateReturnTypeCompilerErrorNumber:
+                    inconsistentAccessibilityProvider = new InconsistentAccessibilityInDelegateReturnType();
+                    break;
+                case InconsistentAccessibilityInDelegateParameterTypeCompilerErrorNumber:
+                    inconsistentAccessibilityProvider = new InconsistentAccessibilityInDelegateParameterType();
+                    break;
             }
 
             return await inconsistentAccessibilityProvider.GetInconsistentAccessibilityInfoAsync(document, diagnostic, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<Location[]> FindTypeLocationsInSourceCodeAsync(Document document, TypeSyntax type, CancellationToken cancellationToken)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var result = new Location[] { };
-
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var typeSymbol = semanticModel.GetSymbolInfo(type, cancellationToken).Symbol;
-
-            if(typeSymbol != null)
+            foreach (var diagnostic in context.Diagnostics)
             {
-                result = typeSymbol.Locations.Where(location => location.IsInSource).ToArray();
+                var inconsistentAccessibilityInfo = await GetInconsistentAccessibilityInfoAsync(context.Document, diagnostic, context.CancellationToken).ConfigureAwait(false);
+
+                await inconsistentAccessibilityCodeFix.FixAsync(context, diagnostic, inconsistentAccessibilityInfo);
             }
-
-            return result;
-        }
-
-        private static async Task<Document> ChangeTypeAccessibilityInDocumentAsync(Solution solution, SyntaxTokenList newAccessibilityModifiers, Location typeLocation, CancellationToken cancellationToken)
-        {
-            var document = solution.GetDocument(typeLocation.SourceTree);
-            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var newRoot = ChangeTypeAccessibilityInSyntaxRoot(syntaxRoot, newAccessibilityModifiers, typeLocation);
-
-            return document.WithSyntaxRoot(newRoot);
-        }
-
-        private static async Task<Solution> ChangeTypeAccessibilityInSolutionAsync(Solution solution, SyntaxTokenList newAccessibilityModifiers, IEnumerable<Location> typeLocations, CancellationToken cancellationToken)
-        {
-            var updatedSolution = solution;
-            var typeLocationsGroupedByDocument = typeLocations.GroupBy(location => solution.GetDocument(location.SourceTree));
-
-            foreach(var typeLocationsWithinDocument in typeLocationsGroupedByDocument)
-            {
-                var document = typeLocationsWithinDocument.Key;
-                var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                var newRoot = ChangeTypesAccessibilityInSyntaxRoot(syntaxRoot, newAccessibilityModifiers, typeLocationsWithinDocument);
-                updatedSolution = updatedSolution.WithDocumentSyntaxRoot(document.Id, newRoot);
-            }
-
-            return updatedSolution;
-        }
-
-        private static SyntaxNode ChangeTypeAccessibilityInSyntaxRoot(SyntaxNode syntaxRoot, SyntaxTokenList newAccessibilityModifiers, Location typeLocation)
-        {
-            var declaration = (MemberDeclarationSyntax)syntaxRoot.FindNode(typeLocation.SourceSpan);
-
-            var newDeclaration = ChangeAccessibilityModifiersInDeclaration(declaration, newAccessibilityModifiers);
-
-            return syntaxRoot.ReplaceNode(declaration, newDeclaration);
-        }
-
-        private static SyntaxNode ChangeTypesAccessibilityInSyntaxRoot(SyntaxNode syntaxRoot, SyntaxTokenList newAccessibilityModifiers, IEnumerable<Location> typeLocations)
-        {
-            var declarations =  typeLocations.Select(typeLocation => (MemberDeclarationSyntax)syntaxRoot.FindNode(typeLocation.SourceSpan)).ToList();
-            var newDeclarations = new Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax>();
-
-            foreach (var declaration in declarations)
-            {
-                newDeclarations.Add(declaration, ChangeAccessibilityModifiersInDeclaration(declaration, newAccessibilityModifiers));
-            }
-
-            return syntaxRoot.ReplaceNodes(declarations, (original, rewritten) => newDeclarations[original]);
-        }
-
-        private static MemberDeclarationSyntax ChangeAccessibilityModifiersInDeclaration(MemberDeclarationSyntax declaration, SyntaxTokenList newAccessibilityModifiers)
-        {
-            var newDeclaration = declaration;
-
-            var actualTypeAccessibilityModifiers = GetAccessibilityModifiersFromMember(declaration);
-            var hasAccessibilityModifiers = actualTypeAccessibilityModifiers.Any();
-
-            var leadingTrivias = default(SyntaxTriviaList);
-            var trailingTrivias = default(SyntaxTriviaList);
-            if (!hasAccessibilityModifiers)
-            {
-                var modifiers = declaration.GetModifiers();
-                if (modifiers.Any())
-                {
-                    var firstModifier = modifiers.First();
-                    leadingTrivias = firstModifier.LeadingTrivia;
-                    newDeclaration = RemoveLeadingTriviasFromFirstDeclarationModifier(declaration, modifiers, firstModifier);
-                }
-                else
-                {
-                    leadingTrivias = declaration.GetLeadingTrivia();
-                    newDeclaration = RemoveLeadingTriviasFromDeclaration(declaration);
-                }
-                trailingTrivias = SyntaxFactory.TriviaList(SyntaxFactory.Space);
-            }
-            else
-            {
-                leadingTrivias = actualTypeAccessibilityModifiers.First().LeadingTrivia;
-                trailingTrivias = GetAllTriviasAfterFirstModifier(actualTypeAccessibilityModifiers);
-            }
-
-            newAccessibilityModifiers = MergeActualTriviasIntoNewAccessibilityModifiers(newAccessibilityModifiers, leadingTrivias, trailingTrivias);
-
-            newDeclaration = ReplaceDeclarationModifiers(newDeclaration, actualTypeAccessibilityModifiers.ToList(), newAccessibilityModifiers);
-
-            return newDeclaration;
-        }
-
-        private static IEnumerable<SyntaxToken> GetAccessibilityModifiersFromMember(MemberDeclarationSyntax member) => member.GetModifiers().Where(token => token.IsKind(SyntaxKind.PublicKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword, SyntaxKind.PrivateKeyword));
-
-        private static MemberDeclarationSyntax RemoveLeadingTriviasFromFirstDeclarationModifier(MemberDeclarationSyntax declaration, SyntaxTokenList modifiers, SyntaxToken modifier) => declaration.WithModifiers(modifiers.Replace(modifier, modifier.WithLeadingTrivia(default(SyntaxTriviaList))));
-
-        private static MemberDeclarationSyntax RemoveLeadingTriviasFromDeclaration(MemberDeclarationSyntax declaration) => declaration.WithoutLeadingTrivia();
-
-        private static SyntaxTriviaList GetAllTriviasAfterFirstModifier(IEnumerable<SyntaxToken> modifiers) => SyntaxFactory.TriviaList(modifiers.Skip(1).SelectMany(token => token.LeadingTrivia).Union(modifiers.SelectMany(token => token.TrailingTrivia)));
-
-        private static MemberDeclarationSyntax ReplaceDeclarationModifiers(MemberDeclarationSyntax declaration, List<SyntaxToken> oldAccessibilityModifiers, SyntaxTokenList newAccessibilityModifiers)
-        {
-            var result = declaration;
-            var replacedModifiers = declaration.GetModifiers();
-
-            if (oldAccessibilityModifiers.Count == 0)
-            {
-                replacedModifiers = replacedModifiers.InsertRange(0,newAccessibilityModifiers);
-            }
-            else if(oldAccessibilityModifiers.Count == 1)
-            {
-                replacedModifiers = replacedModifiers.ReplaceRange(oldAccessibilityModifiers[0], newAccessibilityModifiers);
-            }
-            else if(oldAccessibilityModifiers.Count == 2)
-            {
-                replacedModifiers = replacedModifiers.ReplaceRange(oldAccessibilityModifiers[0], newAccessibilityModifiers);
-                replacedModifiers = replacedModifiers.Remove(replacedModifiers.SingleOrDefault(token => token.IsKind(oldAccessibilityModifiers[1].Kind())));
-            }
-
-            result = declaration.WithModifiers(replacedModifiers);
-
-            return result;
-        }
-
-        private static SyntaxTokenList MergeActualTriviasIntoNewAccessibilityModifiers(SyntaxTokenList modifiers, SyntaxTriviaList leadingTrivias, SyntaxTriviaList trailingTrivias)
-        {
-            if (modifiers.Count == 1)
-            {
-                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(leadingTrivias).WithTrailingTrivia(trailingTrivias));
-            }
-            else if (modifiers.Count == 2)
-            {
-                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(leadingTrivias));
-                modifiers = modifiers.Replace(modifiers[1], modifiers[1].WithTrailingTrivia(trailingTrivias));
-            }
-
-            return modifiers;
         }
     }
 }

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInDelegateParameterType.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInDelegateParameterType.cs
@@ -1,0 +1,44 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class InconsistentAccessibilityInDelegateParameterType : InconsistentAccessibilityInfoProvider
+    {
+        private static readonly LocalizableString CodeActionMessage =
+    new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInDelegateParameter_Title),
+        Resources.ResourceManager, typeof(Resources));
+
+        public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var result = new InconsistentAccessibilityInfo();
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nodeWhenErrorOccured = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
+            var delegateDeclarationThatRaisedError =
+                nodeWhenErrorOccured.FirstAncestorOrSelfOfType<DelegateDeclarationSyntax>();
+
+            if (delegateDeclarationThatRaisedError != null)
+            {
+                var parameterType = ExtractParameterTypeFromDiagnosticMessage(diagnostic);
+
+                result.TypeToChangeAccessibility =
+                    delegateDeclarationThatRaisedError.ParameterList.Parameters.FindTypeInParametersList(parameterType);
+                result.CodeActionMessage = string.Format(CodeActionMessage.ToString(), parameterType,
+                    delegateDeclarationThatRaisedError.Identifier.Text);
+                result.NewAccessibilityModifiers = delegateDeclarationThatRaisedError.Modifiers.CloneAccessibilityModifiers();
+            }
+
+            return result;
+        }
+
+        private static string ExtractParameterTypeFromDiagnosticMessage(Diagnostic diagnostic) =>
+            Regex.Match(diagnostic.GetMessage(CultureInfo.InvariantCulture),
+                "Inconsistent accessibility: parameter type '(.*)' is less accessible than delegate '(.*)'").Groups[1]
+                .Value;
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInDelegateReturnType.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInDelegateReturnType.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodeCracker.CSharp.Design.InconsistentAccessibility
+{
+    public sealed class InconsistentAccessibilityInDelegateReturnType : InconsistentAccessibilityInfoProvider
+    {
+        private static readonly LocalizableString CodeActionMessage =
+            new LocalizableResourceString(nameof(Resources.InconsistentAccessibilityInDelegateReturnType_Title),
+                Resources.ResourceManager, typeof (Resources));
+
+        public async Task<InconsistentAccessibilityInfo> GetInconsistentAccessibilityInfoAsync(Document document,
+            Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var result = new InconsistentAccessibilityInfo();
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nodeWhenErrorOccured = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
+            var delegateDeclarationThatRaisedError =
+                nodeWhenErrorOccured.FirstAncestorOrSelfOfType<DelegateDeclarationSyntax>();
+
+            if (delegateDeclarationThatRaisedError != null)
+            {
+                var type = delegateDeclarationThatRaisedError.ReturnType;
+                result.TypeToChangeAccessibility = type;
+
+                result.CodeActionMessage = string.Format(CodeActionMessage.ToString(),
+                    delegateDeclarationThatRaisedError.ReturnType,
+                    delegateDeclarationThatRaisedError.Identifier.ValueText);
+
+                result.NewAccessibilityModifiers =
+                    delegateDeclarationThatRaisedError.Modifiers.CloneAccessibilityModifiers();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodParameter.cs
+++ b/src/CSharp/CodeCracker/Design/InconsistentAccessibility/InconsistentAccessibilityInMethodParameter.cs
@@ -1,14 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
+﻿using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using System.Globalization;
 using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CodeCracker.CSharp.Design.InconsistentAccessibility
 {

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -134,6 +134,24 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change parameter type &apos;{0}&apos; accessibility to be as accessible as delegate &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInDelegateParameter_Title {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInDelegateParameter_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change delegate return type &apos;{0}&apos; accessibility to be as accessible as delegate &apos;{1}&apos;.
+        /// </summary>
+        public static string InconsistentAccessibilityInDelegateReturnType_Title {
+            get {
+                return ResourceManager.GetString("InconsistentAccessibilityInDelegateReturnType_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change field type &apos;{0}&apos; accessibility to be as accessible as field &apos;{1}&apos;.
         /// </summary>
         public static string InconsistentAccessibilityInFieldType_Title {

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -267,4 +267,10 @@
   <data name="PreferAnyToCountGreaterThanZeroAnalyzer_MessageFormat" xml:space="preserve">
     <value>A call to 'Count({0}) &gt; 0' can be changed to 'Any({0})'</value>
   </data>
+  <data name="InconsistentAccessibilityInDelegateReturnType_Title" xml:space="preserve">
+    <value>Change delegate return type '{0}' accessibility to be as accessible as delegate '{1}'</value>
+  </data>
+  <data name="InconsistentAccessibilityInDelegateParameter_Title" xml:space="preserve">
+    <value>Change parameter type '{0}' accessibility to be as accessible as delegate '{1}'</value>
+  </data>
 </root>

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -123,6 +123,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChangeCultureTests.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.Delegate.cs" />
     <Compile Include="Design\InconsistentAccessibilityTests.MethodIndexerParameter.cs" />
     <Compile Include="Design\InconsistentAccessibilityTests.MethodIndexerReturnType.cs" />
     <Compile Include="Design\MakeMethodStaticTests.cs" />
@@ -213,6 +214,7 @@
     <Compile Include="Design\InconsistentAccessibilityTests.FieldPropertyType.cs" />
     <Compile Include="Design\InconsistentAccessibilityTests.OperatorReturnType.cs" />
     <Compile Include="Design\InconsistentAccessibilityTests.OperatorParameter.cs" />
+    <Compile Include="Design\InconsistentAccessibilityTests.AccessibilityDomainChecker.cs" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.AccessibilityDomainChecker.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.AccessibilityDomainChecker.cs
@@ -1,0 +1,185 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CodeCracker.CSharp.Design.InconsistentAccessibility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
+    {
+        private readonly InconsistentAccessibilityCodeFixStub stub = new InconsistentAccessibilityCodeFixStub();
+
+        [Fact]
+        public async Task
+            ShouldOverwriteTypeToChangeAccessibilityIfInconsistentAccessibilityIsCausedByAccessibilityDomainAsync()
+        {
+            const string testCode =
+                @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedPublicClass param);
+
+internal class InternalClass
+{
+    public class NestedPublicClass { }
+}";
+
+            var document = CreateDocument(testCode, LanguageNames.CSharp, LanguageVersion.CSharp6);
+            var syntaxRoot = await document.GetSyntaxRootAsync();
+            var descendants = syntaxRoot.DescendantNodesAndSelf();
+            var diagnostic = CreateCs0059DiagnosticForDelegateDeclaration(descendants);
+            var typeSyntax = GetTypeSyntaxFromFirstParameterInDelegateDeclaration(descendants);
+
+            var sut = new AccessibilityDomainChecker(stub);
+
+            var context = new CodeFixContext(document, diagnostic, (action, array) => { }, CancellationToken.None);
+            await
+                sut.FixAsync(context, diagnostic, CreateInfoFor(typeSyntax))
+                    .ConfigureAwait(false);
+
+            AssertThatTypeToChangeAccessibilityIs("InternalClass");
+        }
+
+        [Fact]
+        public async Task
+    ShouldHandleDeepNestingWhenCheckingAccessibilityDomainAsync()
+        {
+            const string testCode =
+                @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedInternalClass.NestedNestedPublicClass param);
+
+internal class InternalClass
+{
+    public class NestedInternalClass 
+    {
+        public class NestedNestedPublicClass { }
+    }
+}";
+
+            var document = CreateDocument(testCode, LanguageNames.CSharp, LanguageVersion.CSharp6);
+            var syntaxRoot = await document.GetSyntaxRootAsync();
+            var descendants = syntaxRoot.DescendantNodesAndSelf();
+            var diagnostic = CreateCs0059DiagnosticForDelegateDeclaration(descendants);
+            var typeSyntax = GetTypeSyntaxFromFirstParameterInDelegateDeclaration(descendants);
+
+            var sut = new AccessibilityDomainChecker(stub);
+
+            var context = new CodeFixContext(document, diagnostic, (action, array) => { }, CancellationToken.None);
+            await
+                sut.FixAsync(context, diagnostic, CreateInfoFor(typeSyntax))
+                    .ConfigureAwait(false);
+
+            AssertThatTypeToChangeAccessibilityIs("InternalClass");
+        }
+
+        [Fact]
+        public async Task
+            ShouldHandleNestedInconsistentAccessibilityWhenCheckingAccessibilityDomainAsync()
+        {
+            const string testCode =
+                @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedInternalClass.NestedNestedPublicClass param);
+
+internal class InternalClass
+{
+    internal class NestedInternalClass 
+    {
+        public class NestedNestedPublicClass { }
+    }
+}";
+
+            var document = CreateDocument(testCode, LanguageNames.CSharp, LanguageVersion.CSharp6);
+            var syntaxRoot = await document.GetSyntaxRootAsync();
+            var descendants = syntaxRoot.DescendantNodesAndSelf();
+            var diagnostic = CreateCs0059DiagnosticForDelegateDeclaration(descendants);
+            var typeSyntax = GetTypeSyntaxFromFirstParameterInDelegateDeclaration(descendants);
+
+            var sut = new AccessibilityDomainChecker(stub);
+
+            var context = new CodeFixContext(document, diagnostic, (action, array) => { }, CancellationToken.None);
+            await
+                sut.FixAsync(context, diagnostic, CreateInfoFor(typeSyntax))
+                    .ConfigureAwait(false);
+
+            AssertThatTypeToChangeAccessibilityIs("InternalClass.NestedInternalClass");
+            AssertThatTypeToChangeAccessibilityIs("InternalClass");
+        }
+
+        [Fact]
+        public async Task
+    ShouldNotOverwriteTypeToChangeAccessibilityIfInconsitentAccessibilityIsNotInAccessibilityDomainAsync()
+        {
+            const string testCode =
+                @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedInternalClass.NestedNestedPublicClass param);
+
+public class InternalClass
+{
+    public class NestedInternalClass 
+    {
+        internal class NestedNestedPublicClass { }
+    }
+}";
+
+            var document = CreateDocument(testCode, LanguageNames.CSharp, LanguageVersion.CSharp6);
+            var syntaxRoot = await document.GetSyntaxRootAsync();
+            var descendants = syntaxRoot.DescendantNodesAndSelf();
+            var diagnostic = CreateCs0059DiagnosticForDelegateDeclaration(descendants);
+            var typeSyntax = GetTypeSyntaxFromFirstParameterInDelegateDeclaration(descendants);
+
+            var sut = new AccessibilityDomainChecker(stub);
+
+            var context = new CodeFixContext(document, diagnostic, (action, array) => { }, CancellationToken.None);
+            await
+                sut.FixAsync(context, diagnostic, CreateInfoFor(typeSyntax))
+                    .ConfigureAwait(false);
+
+            AssertThatTypeToChangeAccessibilityIs("InternalClass.NestedInternalClass.NestedNestedPublicClass");
+        }
+
+        private void AssertThatTypeToChangeAccessibilityIs(string name)
+        {
+            Assert.Contains(stub.PassedInfo,
+                accessibilityInfo => string.Equals(accessibilityInfo.TypeToChangeAccessibility.ToString(), name));
+        }
+
+        private static InconsistentAccessibilityInfo CreateInfoFor(TypeSyntax typeSyntax)
+            =>
+                new InconsistentAccessibilityInfo
+                {
+                    NewAccessibilityModifiers = SyntaxTokenList.Create(SyntaxFactory.Token(SyntaxKind.PublicKeyword)),
+                    TypeToChangeAccessibility = typeSyntax
+                };
+
+        private static Diagnostic CreateCs0059DiagnosticForDelegateDeclaration(IEnumerable<SyntaxNode> descendants)
+        {
+            var delegateDeclaration = descendants.OfType<DelegateDeclarationSyntax>().Single();
+
+            return
+                Diagnostic.Create(
+                    new DiagnosticDescriptor("CS0059", "Title", "Format", "Category", DiagnosticSeverity.Error, true),
+                    delegateDeclaration.GetLocation());
+        }
+
+        private static TypeSyntax GetTypeSyntaxFromFirstParameterInDelegateDeclaration(
+            IEnumerable<SyntaxNode> descendants) =>
+                descendants.OfType<DelegateDeclarationSyntax>().Single().ParameterList.Parameters.First().Type;
+    }
+
+    public class InconsistentAccessibilityCodeFixStub : IInconsistentAccessibilityCodeFix
+    {
+        public InconsistentAccessibilityCodeFixStub()
+        {
+            PassedInfo = new List<InconsistentAccessibilityInfo>();
+        }
+
+        public List<InconsistentAccessibilityInfo> PassedInfo { get; private set; }
+
+        public async Task FixAsync(CodeFixContext context, Diagnostic diagnostic, InconsistentAccessibilityInfo info)
+        {
+            PassedInfo.Add(info);
+
+            await Task.FromResult(true);
+        }
+    }
+}

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.Delegate.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.Delegate.cs
@@ -1,0 +1,102 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public partial class InconsistentAccessibilityTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task ShouldFixReturnTypeInconsistentAccessibilityInDelegateThatIsNamespaceMemberAsync()
+        {
+            const string testCode = @"public delegate InternalClass DelegateThatIsNamespaceMember();
+class InternalClass { }";
+
+            const string fixedCode = @"public delegate InternalClass DelegateThatIsNamespaceMember();
+public class InternalClass { }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixReturnTypeInconsistentAccessibilityInDelegateThatIsTypeMemberAsync()
+        {
+            const string testCode = @"public class ClassWithDelegateDeclaration
+{
+    public delegate InternalClass Delegate();
+}
+internal class InternalClass { }";
+
+            const string fixedCode = @"public class ClassWithDelegateDeclaration
+{
+    public delegate InternalClass Delegate();
+}
+public class InternalClass { }";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixParameterTypeInconsinstentAccessibilityInDelegateThatIsNamespaceMemberAsync()
+        {
+            const string testCode = @"public delegate void DelegateThatIsNamespaceMember(PublicClass.NestedInternalClass param);
+
+public class PublicClass
+{
+    internal class NestedInternalClass { }
+}";
+
+            const string fixedCode = @"public delegate void DelegateThatIsNamespaceMember(PublicClass.NestedInternalClass param);
+
+public class PublicClass
+{
+    public class NestedInternalClass { }
+}";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixParameterTypeInconsinstentAccessibilityInDelegateThatIsTypeMemberAsync()
+        {
+            const string testCode = @"public class ClassWithDelegateDeclaration
+{
+    public delegate void Delegate(PublicClass.NestedInternalClass param);
+}
+public class PublicClass
+{
+    internal class NestedInternalClass { }
+}";
+
+            const string fixedCode = @"public class ClassWithDelegateDeclaration
+{
+    public delegate void Delegate(PublicClass.NestedInternalClass param);
+}
+public class PublicClass
+{
+    public class NestedInternalClass { }
+}";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFixParameterTypeInconsinstentAccessibilityInDelegateWhenContainingTypeHasInsufficientAccessibility()
+        {
+            const string testCode = @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedPublicClass param);
+
+internal class InternalClass
+{
+    public class NestedPublicClass { }
+}";
+
+            const string fixedCode = @"public delegate void DelegateThatIsNamespaceMember(InternalClass.NestedPublicClass param);
+
+public class InternalClass
+{
+    public class NestedPublicClass { }
+}";
+
+            await VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorReturnType.cs
+++ b/test/CSharp/CodeCracker.Test/Design/InconsistentAccessibilityTests.OperatorReturnType.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
+﻿using System.Threading.Tasks;
 using Xunit;
 
 namespace CodeCracker.Test.CSharp.Design

--- a/test/Common/CodeCracker.Test.Common/Helpers/DiagnosticVerifier.Helper.cs
+++ b/test/Common/CodeCracker.Test.Common/Helpers/DiagnosticVerifier.Helper.cs
@@ -145,6 +145,19 @@ namespace CodeCracker.Test
             CreateProject(new[] { source }, language, languageVersionCSharp, languageVersionVB).Documents.First();
 
         /// <summary>
+        /// Create a Document from a string through creating a project that contains it.
+        /// </summary>
+        /// <param name="source">Classes in the form of a string</param>
+        /// <param name="language">The language the source code is in</param>
+        /// <param name="languageVersionCSharp">C# language version used for compiling the test project, required unless you inform the VB language version.</param>
+        /// <returns>A Document created from the source string</returns>
+        public static Document CreateDocument(string source,
+            string language,
+            LanguageVersion languageVersionCSharp) =>
+                CreateProject(new[] {source}, language, languageVersionCSharp,
+                    Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14).Documents.First();
+
+        /// <summary>
         /// Create a project using the inputted strings as sources.
         /// </summary>
         /// <param name="sources">Classes in the form of strings</param>


### PR DESCRIPTION
Fixes `CS0058` and `CS0059` in #381.

Implementation with tests for `CS0058` and `CS0059` compiler error numbers.

Additionally I added checking if reason for inconsistent accessibility is in accessibility domain instead of actual accessibility modifiers of type in cause of nested types.

I created a `CreateDocument` method overload without `LanguageVersion` for `VisualBasic` in `DiagnosticVerifier.cs` because I wanted to avoid draging dependency to `..CodeAnalysis.VisualBasic` for `CodeCracker.Test` `C#` project
