### PR TITLE
Fix UnusedParametersCodeFixProvider crashing when removing params

### DIFF
--- a/src/CSharp/CodeCracker/Usage/UnusedParametersCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Usage/UnusedParametersCodeFixProvider.cs
@@ -82,10 +82,10 @@ namespace CodeCracker.CSharp.Usage
                     if (parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword)))
                     {
                         var newArguments = arguments;
-                        do
+                        while (newArguments.Arguments.Count > parameterPosition)
                         {
                             newArguments = newArguments.WithArguments(newArguments.Arguments.RemoveAt(parameterPosition));
-                        } while (newArguments.Arguments.Count > parameterPosition);
+                        }
                         replacingArgs.Add(arguments, newArguments);
                     }
                     else

--- a/src/VisualBasic/CodeCracker/Usage/UnusedParametersCodeFixProvider.vb
+++ b/src/VisualBasic/CodeCracker/Usage/UnusedParametersCodeFixProvider.vb
@@ -73,9 +73,9 @@ Namespace Usage
                         methodIdentifier.FirstAncestorOfType(Of InvocationExpressionSyntax).ArgumentList)
                     If parameter.Modifiers.Any(Function(m) m.IsKind(SyntaxKind.ParamArrayKeyword)) Then
                         Dim newArguments = arguments
-                        Do
+                        While newArguments.Arguments.Count > parameterPosition
                             newArguments = newArguments.WithArguments(newArguments.Arguments.RemoveAt(parameterPosition))
-                        Loop While newArguments.Arguments.Count > parameterPosition
+                        End While
                         replacingArgs.Add(arguments, newArguments)
                     Else
                         Dim newArguments = arguments.WithArguments(arguments.Arguments.RemoveAt(parameterPosition))

--- a/test/CSharp/CodeCracker.Test/Usage/UnusedParametersTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/UnusedParametersTests.cs
@@ -343,6 +343,36 @@ class TypeName
         }
 
         [Fact]
+        public async Task FixParamsWhenNotInUse()
+        {
+            const string source = @"
+class TypeName
+{
+    public void IsReferencing()
+    {
+        Foo(1, 2);
+    }
+    public void Foo(int a, int b, params int[] c)
+    {
+        a = b;
+    }
+}";
+            const string fixtest = @"
+class TypeName
+{
+    public void IsReferencing()
+    {
+        Foo(1, 2);
+    }
+    public void Foo(int a, int b)
+    {
+        a = b;
+    }
+}";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
         public async Task FixAllInSameClass()
         {
             const string source = @"

--- a/test/VisualBasic/CodeCracker.Test/CodeCracker.Test.vbproj
+++ b/test/VisualBasic/CodeCracker.Test/CodeCracker.Test.vbproj
@@ -180,7 +180,7 @@
     <Compile Include="Usage\DisposableFieldNotDisposedTests.vb" />
     <Compile Include="Usage\ArgumentExceptionTests.vb" />
     <Compile Include="Usage\IPAddressAnalyzerTests.vb" />
-    <Compile Include="Usage\UnusedParameterTests.vb" />
+    <Compile Include="Usage\UnusedParametersTests.vb" />
     <Compile Include="Usage\JsonNetTests.vb" />
     <Compile Include="Usage\MustInheritClassShouldNotHavePublicConstructorTests.vb" />
     <Compile Include="Usage\RemovePrivateMethodNeverUsedAnalyzerTest.vb" />

--- a/test/VisualBasic/CodeCracker.Test/Usage/UnusedParametersTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Usage/UnusedParametersTests.vb
@@ -2,7 +2,7 @@
 Imports Xunit
 
 Namespace Usage
-    Public Class UnusedParameterTests
+    Public Class UnusedParametersTests
         Inherits CodeFixVerifier(Of UnusedParametersAnalyzer, UnusedParametersCodeFixProvider)
         <Fact>
         Public Async Function MethodWithoutParametersDoesNotCreateDiagnostic() As Task
@@ -357,6 +357,31 @@ End Class"
 Class Foo
     Public Sub IsReferencing()
         Dim x = Bar(1, 2, 3, 4)
+    End Sub
+    Public Function Bar(a As Integer, b As Integer, ParamArray c As Integer())
+        b = a
+        return 1
+    End Function
+End Class"
+            Const fix = "
+Class Foo
+    Public Sub IsReferencing()
+        Dim x = Bar(1, 2)
+    End Sub
+    Public Function Bar(a As Integer, b As Integer)
+        b = a
+        return 1
+    End Function
+End Class"
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
+
+        <Fact>
+        Public Async Function FixParamsWhenNotInUse() As Task
+            Const source = "
+Class Foo
+    Public Sub IsReferencing()
+        Dim x = Bar(1, 2)
     End Sub
     Public Function Bar(a As Integer, b As Integer, ParamArray c As Integer())
         b = a


### PR DESCRIPTION
Closes #539 for both VB and C#