### PR TITLE
Fix failing ValidateColor tests in some cultures

### DIFF
--- a/test/Common/CodeCracker.Test.Common/ChangeCulture.cs
+++ b/test/Common/CodeCracker.Test.Common/ChangeCulture.cs
@@ -1,23 +1,37 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Globalization;
+using System.Threading;
 
 namespace CodeCracker.Test
 {
     public class ChangeCulture : IDisposable
     {
+        private readonly CultureInfo _originalCulture;
+        private readonly CultureInfo _originalUICulture;
+        private readonly CultureInfo _originalDefaultCulture;
+        private readonly CultureInfo _originalDefaultUICulture;
+
         public ChangeCulture(string cultureName)
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(cultureName);
-            System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(cultureName);
+            _originalCulture = Thread.CurrentThread.CurrentCulture;
+            _originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            _originalDefaultCulture = CultureInfo.DefaultThreadCurrentCulture;
+            _originalDefaultUICulture = CultureInfo.DefaultThreadCurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture =
+            Thread.CurrentThread.CurrentUICulture =
+            CultureInfo.DefaultThreadCurrentCulture =
+            CultureInfo.DefaultThreadCurrentUICulture =
+                CultureInfo.GetCultureInfo(cultureName);
+
         }
 
         public void Dispose()
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
-            System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentCulture = _originalCulture;
+            Thread.CurrentThread.CurrentUICulture = _originalUICulture;
+            CultureInfo.DefaultThreadCurrentCulture = _originalDefaultCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = _originalDefaultUICulture;
             GC.SuppressFinalize(this);
         }
     }


### PR DESCRIPTION
Some tests in ValidateColorTests were failing in French culture. This is because `"200,100,50"` is a valid color in English, but not in French, because the list separator is different. See the comments [here](https://github.com/code-cracker/code-cracker/issues/1#issuecomment-154075860) for details.

I made a few changes to the `ChangeCulture` class:
- set the `DefaultThreadCurrentCulture` and `DefaultThreadCurrentUICulture` properties so that the new culture also applies to other threads in async code
- save the original values to be able to restore them later