### PR TITLE
Reorganize StringFormatArgsAnalyzer to use the correct severities

### DIFF
--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -49,7 +49,7 @@
         SimplifyRedundantBooleanComparisons = 49,
         ReadonlyField = 52,
         JsonNet = 54,
-        StringFormatArgs = 56,
+        StringFormatArgs_InvalidArgs = 56,
         UnusedParameters = 57,
         AbstractClassShouldNotHavePublicCtors = 60,
         TaskNameAsync = 61,
@@ -78,5 +78,6 @@
         ChangeAllToAny = 92,
         ConsoleWriteLine = 95,
         NameOf_External = 108,
+        StringFormatArgs_ExtraArgs = 111,
     }
 }

--- a/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
@@ -79,6 +79,20 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
+        public async Task NoParametersCreatesError()
+        {
+            var source = @"var result = string.Format(""{0}"");".WrapInCSharpMethod();
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.StringFormatArgs_InvalidArgs.ToDiagnosticId(),
+                Message = StringFormatArgsAnalyzer.InvalidArgsReferenceMessage,
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
         public async Task LessParametersCreatesError()
         {
             var source = @"var result = string.Format(""one {0} two {1}"", ""a"");".WrapInCSharpMethod();

--- a/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/StringFormatArgsTests.cs
@@ -6,7 +6,7 @@ using CodeCracker.CSharp.Usage;
 
 namespace CodeCracker.Test.CSharp.Usage
 {
-    public class StringFormatTests : CodeFixVerifier
+    public class StringFormatArgsTests : CodeFixVerifier
     {
         protected override DiagnosticAnalyzer GetDiagnosticAnalyzer() => new StringFormatArgsAnalyzer();
 
@@ -79,13 +79,13 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task MethodsWithLessParametersCreatesDiagnostic()
+        public async Task LessParametersCreatesError()
         {
             var source = @"var result = string.Format(""one {0} two {1}"", ""a"");".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
-                Message = StringFormatArgsAnalyzer.IncorrectNumberOfArgsMessage,
+                Id = DiagnosticId.StringFormatArgs_InvalidArgs.ToDiagnosticId(),
+                Message = StringFormatArgsAnalyzer.InvalidArgsReferenceMessage,
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
             };
@@ -93,14 +93,14 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task MethodsWithMoreParametersCreatesDiagnostic()
+        public async Task MoreArgumentsCreatesWarning()
         {
             var source = @"var result = string.Format(""one {0} two {1}"", ""a"", ""b"", ""c"");".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
+                Id = DiagnosticId.StringFormatArgs_ExtraArgs.ToDiagnosticId(),
                 Message = StringFormatArgsAnalyzer.IncorrectNumberOfArgsMessage,
-                Severity = DiagnosticSeverity.Error,
+                Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
@@ -128,14 +128,14 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task MethodWithMultibleParamtersReferencingSingleArgumentCreatesDiagnostic()
+        public async Task TwoParametersReferencingSamePlaceholderCreatesWarning()
         {
             var source = @"var result = string.Format(""one {0} two {0}"", ""a"", ""b"");".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
+                Id = DiagnosticId.StringFormatArgs_ExtraArgs.ToDiagnosticId(),
                 Message = StringFormatArgsAnalyzer.IncorrectNumberOfArgsMessage,
-                Severity = DiagnosticSeverity.Error,
+                Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
@@ -163,7 +163,7 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task VerbatimStringWithIncorrectNumberOfHolesCreatesDiagnostic()
+        public async Task VerbatimStringWithMissingArgCreatesError()
         {
             var source = @"
                 var noun = ""Giovanni"";
@@ -171,8 +171,8 @@ namespace CodeCracker.Test.CSharp.Usage
 """"{1}""""."", noun);".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
-                Message = StringFormatArgsAnalyzer.IncorrectNumberOfArgsMessage,
+                Id = DiagnosticId.StringFormatArgs_InvalidArgs.ToDiagnosticId(),
+                Message = StringFormatArgsAnalyzer.InvalidArgsReferenceMessage,
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 25) }
             };
@@ -180,12 +180,12 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task MethodWithInvalidArgumentReferenceCreatesDiagnostic()
+        public async Task InvalidArgumentReferenceCreatesError()
         {
             var source = @"var result = string.Format(""one {1}"", ""a"");".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
+                Id = DiagnosticId.StringFormatArgs_InvalidArgs.ToDiagnosticId(),
                 Message = StringFormatArgsAnalyzer.InvalidArgsReferenceMessage,
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
@@ -194,15 +194,29 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
-        public async Task MethodWithVeryInvalidArgumentReferenceCreatesDiagnostic()
+        public async Task NonIntegerPlaceholderCreatesError()
         {
             var source = @"var result = string.Format(""one {notZero}"", ""a"");".WrapInCSharpMethod();
             var expected = new DiagnosticResult
             {
-                Id = DiagnosticId.StringFormatArgs.ToDiagnosticId(),
+                Id = DiagnosticId.StringFormatArgs_InvalidArgs.ToDiagnosticId(),
                 Message = StringFormatArgsAnalyzer.InvalidArgsReferenceMessage,
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 30) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task UnusedArgsCreatesWarning()
+        {
+            var source = @"string.Format(""{0}{1}{3}{5}"", ""a"", ""b"", ""c"", ""d"", ""e"", ""f"");".WrapInCSharpMethod();
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.StringFormatArgs_ExtraArgs.ToDiagnosticId(),
+                Message = StringFormatArgsAnalyzer.IncorrectNumberOfArgsMessage,
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }


### PR DESCRIPTION
Fixes #585
StringFormatArgsAnalyzer was always raising an error, when it is not an
error to have extra parameters. So we have taken an extra id, CC0111 to
use as the warning, when string.Format is being provided more arguments
than the format string is requiring.
This will now raise a warning:

    string.Format("{0}", "a", "b");

When string.Format has less arguments than the format string requires,
we are still raising CC0056, as an error, as it will generate a
runtime error.
This will now raise an error:

    string.Format("{0}{1}", "a");

Other verifications the analyzer was already checking continue as
before.