### PR TITLE
Fix ChangeAnyToAllAnalyzer for negated expressions and expression bodied methods

### DIFF
--- a/src/CSharp/CodeCracker/Refactoring/ChangeAnyToAllAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Refactoring/ChangeAnyToAllAnalyzer.cs
@@ -49,20 +49,31 @@ namespace CodeCracker.CSharp.Refactoring
             if (invocation.Parent?.IsKind(SyntaxKind.ExpressionStatement) ?? true) return;
             var diagnosticToRaise = GetCorrespondingDiagnostic(context.SemanticModel, invocation);
             if (diagnosticToRaise == null) return;
-            var diagnostic = Diagnostic.Create(diagnosticToRaise, ((MemberAccessExpressionSyntax)invocation.Expression).Name.GetLocation());
+            var diagnostic = Diagnostic.Create(diagnosticToRaise, GetName(invocation).GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
 
         private static DiagnosticDescriptor GetCorrespondingDiagnostic(SemanticModel semanticModel, InvocationExpressionSyntax invocation)
         {
-            var methodName = (invocation?.Expression as MemberAccessExpressionSyntax)?.Name?.ToString();
-            var nameToCheck = methodName == "Any" ? allName : methodName == "All" ? anyName : null;
+            var methodName = GetName(invocation);
+            var methodNameText = methodName?.ToString();
+            var nameToCheck = methodNameText == "Any" ? allName : methodNameText == "All" ? anyName : null;
             if (nameToCheck == null) return null;
             var methodSymbol = semanticModel.GetSymbolInfo(invocation.Expression).Symbol as IMethodSymbol;
             if (methodSymbol?.Parameters.Length != 1) return null;
             if (!IsLambdaWithoutBody(invocation)) return null;
             if (!OtherMethodExists(invocation, nameToCheck, semanticModel)) return null;
-            return methodName == "Any" ? RuleAny : RuleAll;
+            return methodNameText == "Any" ? RuleAny : RuleAll;
+        }
+
+        public static SimpleNameSyntax GetName(InvocationExpressionSyntax invocation)
+        {
+            SimpleNameSyntax methodName = null;
+            if (invocation.Expression.IsKind(SyntaxKind.MemberBindingExpression))
+                methodName = ((MemberBindingExpressionSyntax)invocation.Expression).Name;
+            else if (invocation.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+                methodName = ((MemberAccessExpressionSyntax)invocation.Expression).Name;
+            return methodName;
         }
 
         private static bool IsLambdaWithoutBody(InvocationExpressionSyntax invocation)
@@ -75,7 +86,7 @@ namespace CodeCracker.CSharp.Refactoring
 
         private static bool OtherMethodExists(InvocationExpressionSyntax invocation, SimpleNameSyntax nameToCheck, SemanticModel semanticModel)
         {
-            var otherExpression = ((MemberAccessExpressionSyntax)invocation.Expression).WithName(nameToCheck).WithAdditionalAnnotations(speculativeAnnotation);
+            var otherExpression = CreateExpressionWithNewName(invocation, nameToCheck);
             var statement = invocation.FirstAncestorOrSelfThatIsAStatement();
             SemanticModel speculativeModel;
             if (statement != null)
@@ -92,6 +103,16 @@ namespace CodeCracker.CSharp.Refactoring
             }
             var symbol = speculativeModel.GetSymbolInfo(speculativeModel.SyntaxTree.GetRoot().GetAnnotatedNodes(speculativeAnnotationDescription).First()).Symbol;
             return symbol != null;
+        }
+
+        public static ExpressionSyntax CreateExpressionWithNewName(InvocationExpressionSyntax invocation, SimpleNameSyntax nameToCheck)
+        {
+            ExpressionSyntax otherExpression = null;
+            if (invocation.Expression.IsKind(SyntaxKind.MemberBindingExpression))
+                otherExpression = ((MemberBindingExpressionSyntax)invocation.Expression).WithName(nameToCheck).WithAdditionalAnnotations(speculativeAnnotation);
+            else //avoid this, already checked before: if (invocation.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+                otherExpression = ((MemberAccessExpressionSyntax)invocation.Expression).WithName(nameToCheck).WithAdditionalAnnotations(speculativeAnnotation);
+            return otherExpression;
         }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Refactoring/ChangeAnyToAllTests.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/ChangeAnyToAllTests.cs
@@ -232,5 +232,45 @@ class TypeName
 }}";
             await VerifyCSharpFixAsync(string.Format(source, code), string.Format(source, fixedCode));
         }
+
+        [Theory]
+        [InlineData("Any", DiagnosticId.ChangeAnyToAll)]
+        [InlineData("All", DiagnosticId.ChangeAllToAny)]
+        public async Task ExpressionBodiedMemberCreatesDiagnostic(string methodName, DiagnosticId diagnosticId)
+        {
+            var source = $@"
+using System;
+using System.Linq;
+class TypeName
+{{
+    private System.Collections.Generic.IList<int> xs;
+    bool Foo() => xs.{methodName}(i => i == 1);
+}}";
+            var expected = new DiagnosticResult
+            {
+                Id = diagnosticId.ToDiagnosticId(),
+                Message = diagnosticId == DiagnosticId.ChangeAnyToAll ? ChangeAnyToAllAnalyzer.MessageAny : ChangeAnyToAllAnalyzer.MessageAll,
+                Severity = DiagnosticSeverity.Hidden,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 22) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Theory]
+        [InlineData("xs.Any(i => i == 1)", "!xs.All(i => i != 1)")]
+        [InlineData("!xs.All(i => i != 1)", "xs.Any(i => i == 1)")]
+        public async Task FixesExpressionBodiedMember(string code, string fixedCode)
+        {
+            var source = @"
+using System;
+using System.Linq;
+class TypeName
+{{
+    private System.Collections.Generic.IList<int> xs;
+    bool Foo() => {0};
+}}";
+            await VerifyCSharpFixAsync(string.Format(source, code), string.Format(source, fixedCode));
+        }
+
     }
 }

--- a/test/CSharp/CodeCracker.Test/Refactoring/ChangeAnyToAllTests.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/ChangeAnyToAllTests.cs
@@ -272,5 +272,32 @@ class TypeName
             await VerifyCSharpFixAsync(string.Format(source, code), string.Format(source, fixedCode));
         }
 
+        [Theory]
+        [InlineData("Any", DiagnosticId.ChangeAnyToAll)]
+        [InlineData("All", DiagnosticId.ChangeAllToAny)]
+        public async Task NegationWithCoalesceExpressionCreatesDiagnostic(string methodName, DiagnosticId diagnosticId)
+        {
+            var source = $@"
+var ints = new [] {{ 1 }};
+var query = !ints?.{methodName}(i => i == 1) ?? true;";
+            var expected = new DiagnosticResult
+            {
+                Id = diagnosticId.ToDiagnosticId(),
+                Message = diagnosticId == DiagnosticId.ChangeAnyToAll ? ChangeAnyToAllAnalyzer.MessageAny : ChangeAnyToAllAnalyzer.MessageAll,
+                Severity = DiagnosticSeverity.Hidden,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 20) }
+            };
+            await VerifyCSharpDiagnosticAsync(source.WrapInCSharpMethod(usings: "\nusing System.Linq;"), expected);
+        }
+
+        [Theory]
+        [InlineData(@"
+            var ints = new [] {1, 2};
+            var query = !ints?.Any(i => i == 1) ?? true;", @"
+            var ints = new [] {1, 2};
+            var query = ints?.All(i => i != 1) ?? true;")]
+        public async Task FixesNegationWithCoalesceExpression(string original, string fix) =>
+            await VerifyCSharpFixAsync(original.WrapInCSharpMethod(usings: "\nusing System.Linq;"),
+                fix.WrapInCSharpMethod(usings: "\nusing System.Linq;"));
     }
 }


### PR DESCRIPTION
This PR fixes 2 things  for ChangeAnyToAllAnalyzer:

* negated expressions, closes #640
* expression bodied methods, closes #641

See tests.