### PR TITLE
Enable DisposableFieldNotDisposedAnalyzer to work with expression bodied methods

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/DisposableFieldNotDisposedTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposableFieldNotDisposedTests.cs
@@ -761,5 +761,21 @@ public class A : IDisposable
     }";
             await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
+
+        [Fact]
+        public async Task AlreadyDisposedDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+class TypeName : System.IDisposable
+{
+    private D field = new D();
+    public void Dispose() => field.Dispose();
+}
+class D : System.IDisposable
+{
+    public void Dispose() { }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
     }
 }


### PR DESCRIPTION
Closes #638
Also refactor CallsDisposeOnField to protect against possible other null reference exceptions.