### PR TITLE
Bug fix cc0091 not working when used with delegates

### DIFF
--- a/src/CSharp/CodeCracker/Design/MakeMethodStaticCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/MakeMethodStaticCodeFixProvider.cs
@@ -72,15 +72,15 @@ namespace CodeCracker.CSharp.Design
             var unchangedRoot = root;
             var memberAccess = root.GetCurrentNode(diagnosticNode).FirstAncestorOrSelfOfType<MemberAccessExpressionSyntax>();
             if (memberAccess == null) return unchangedRoot;
-            if (IsTypeOfExpresion<ThisExpressionSyntax>(memberAccess.Expression))
+            if (IsTypeOfExpression<ThisExpressionSyntax>(memberAccess.Expression))
             {
                 var newMemberAccessParent = memberAccess.Parent.ReplaceNode(memberAccess, memberAccess.Name)
                     .WithAdditionalAnnotations(Formatter.Annotation);
                 return root.ReplaceNode(memberAccess.Parent, newMemberAccessParent);
             }
-            else if (IsTypeOfExpresion<ObjectCreationExpressionSyntax>(memberAccess.Expression))
+            else if (IsTypeOfExpression<ObjectCreationExpressionSyntax>(memberAccess.Expression))
             {
-                var newObjectCreationExpression = SyntaxFactory.ExpressionStatement(GetObjectCreationExpresion(memberAccess.Expression));
+                var newObjectCreationExpression = SyntaxFactory.ExpressionStatement(GetObjectCreationExpression(memberAccess.Expression));
                 var nodeToInsertBefor = GetLastNodeBeforeBlockSyntax(root.GetCurrentNode(diagnosticNode));
                 var oldBlock = nodeToInsertBefor.Parent;
                 var newBlock = oldBlock.InsertNodesBefore(nodeToInsertBefor, new[] { newObjectCreationExpression });
@@ -96,7 +96,6 @@ namespace CodeCracker.CSharp.Design
                         .WithAdditionalAnnotations(Formatter.Annotation);
                 return root.ReplaceNode(memberAccess.Parent, newMemberAccessParent);
             }
-
         }
 
         private static SyntaxNode GetLastNodeBeforeBlockSyntax(SyntaxNode node)
@@ -109,28 +108,27 @@ namespace CodeCracker.CSharp.Design
             return null;
         }
 
-        private static bool IsTypeOfExpresion<T>(ExpressionSyntax expression) where T : SyntaxNode
+        private static bool IsTypeOfExpression<T>(ExpressionSyntax expression) where T : SyntaxNode
         {
             while (expression != null)
             {
                 if (expression.GetType() == typeof(T)) return true;
-                expression = GetNextExpresion(expression);
+                expression = GetNextExpression(expression);
             }
             return false;
         }
 
-        private static ObjectCreationExpressionSyntax GetObjectCreationExpresion(ExpressionSyntax expression)
+        private static ObjectCreationExpressionSyntax GetObjectCreationExpression(ExpressionSyntax expression)
         {
-
             while (expression != null)
             {
                 if (expression.IsKind(SyntaxKind.ObjectCreationExpression)) return expression as ObjectCreationExpressionSyntax;
-                expression = GetNextExpresion(expression);
+                expression = GetNextExpression(expression);
             }
             return null;
         }
 
-        private static ExpressionSyntax GetNextExpresion(ExpressionSyntax expression)
+        private static ExpressionSyntax GetNextExpression(ExpressionSyntax expression)
         {
             if (expression.IsKind(SyntaxKind.ParenthesizedExpression))
                 return (expression as ParenthesizedExpressionSyntax).Expression;

--- a/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
@@ -8,6 +8,262 @@ namespace CodeCracker.Test.CSharp.Design
 {
     public class MakeMethodStaticTests : CodeFixVerifier<MakeMethodStaticAnalyzer, MakeMethodStaticCodeFixProvider>
     {
+
+        [Fact]
+        public async Task MakeMethodStaticWithReferenceAsDelegateInDifferentDocs()
+        {
+            var source1 = @"public void Foo() { }".WrapInCSharpClass("X");
+
+            var source2 = @"
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += ((this).Foo);
+            }".WrapInCSharpClass("Y : X");
+
+            var fixtest1 = @"public static void Foo() { }".WrapInCSharpClass("X");
+
+            var fixtest2 = @"
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += (Foo);
+            }".WrapInCSharpClass("Y : X");
+            await VerifyCSharpFixAllAsync(new[] { source1, source2 }, new[] { fixtest1, fixtest2 });
+        }
+
+        [Fact]
+        public async Task MakeMethodStaticWhenReferencedAsNewInOtherClass()
+        {
+            const string source = @"
+using System;
+namespace ConsoleApplication1
+{
+    class Type1
+    {
+        public static bool Initialized = false;
+        public void Foo()
+        {
+            Initialized = true;
+        }
+    }
+    class Type2
+    {
+        private int i = 0;
+        public void Bar() {
+            var a = ((Type1)new Type1()).Foo();
+            var b = ((Type1)new Type1()).Foo();
+            i++;
+        }
+    }
+}";
+            const string fixtest = @"
+using System;
+namespace ConsoleApplication1
+{
+    class Type1
+    {
+        public static bool Initialized = false;
+        public static void Foo()
+        {
+            Initialized = true;
+        }
+    }
+    class Type2
+    {
+        private int i = 0;
+        public void Bar() {
+            new Type1();
+            var a = Type1.Foo();
+            new Type1();
+            var b = Type1.Foo();
+            i++;
+        }
+    }
+}";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task MakeMethodStaticWhenReferencedInOtherClass()
+        {
+            const string source = @"
+using System;
+namespace ConsoleApplication1
+{
+    class Type1
+    {
+        public void Foo()
+        {
+        }
+    }
+    class Type2
+    {
+        private int i = 0;
+        private void Foo() { i++; }
+        public void Bar() {
+            var a = new Type1();
+            a.Foo()
+            Foo();
+            i++;
+        }
+    }
+}";
+            const string fixtest = @"
+using System;
+namespace ConsoleApplication1
+{
+    class Type1
+    {
+        public static void Foo()
+        {
+        }
+    }
+    class Type2
+    {
+        private int i = 0;
+        private void Foo() { i++; }
+        public void Bar() {
+            var a = new Type1();
+            Type1.Foo()
+            Foo();
+            i++;
+        }
+    }
+}";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task MakeMethodStaticWithReferenceAsDelegateInDifferentClass()
+        {
+            const string source = @"
+        class X
+        {
+            public void Foo()
+            {
+            }
+        }
+
+        class Y
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                var f = new X();
+                Changed += f.Foo;
+            }
+        }";
+
+            const string fixtest = @"
+        class X
+        {
+            public static void Foo()
+            {
+            }
+        }
+
+        class Y
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                var f = new X();
+                Changed += X.Foo;
+            }
+        }";
+
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task MakeMethodStaticWithReferenceAsDelegateWithoutThis()
+        {
+            const string source = @"
+        class X
+        {
+            public void Foo()
+            {
+            }
+        }
+
+        class Y : X
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += Foo;
+            }
+        }";
+
+            const string fixtest = @"
+        class X
+        {
+            public static void Foo()
+            {
+            }
+        }
+
+        class Y : X
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += Foo;
+            }
+        }";
+
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task MakeMethodStaticWithReferenceAsDelegate()
+        {
+            const string source = @"
+        class X
+        {
+            public void Foo()
+            {
+            }
+        }
+
+        class Y : X
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += ((this).Foo);
+            }
+        }";
+
+            const string fixtest = @"
+        class X
+        {
+            public static void Foo()
+            {
+            }
+        }
+
+        class Y : X
+        {
+            public event Action Changed;
+
+            public void Goo()
+            {
+                Changed += (Foo);
+            }
+        }";
+
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
         [Theory]
         [InlineData(@"static void Foo() { }")]
         [InlineData(@"public virtual void Foo() { }")]
@@ -199,6 +455,7 @@ void Bar()
     t.Foo();
 }".WrapInCSharpClass("Type1");
             var source2 = @"public void Foo() { }".WrapInCSharpClass("Type2");
+
             var fixtest1 = @"private int i;
 void Bar()
 {

--- a/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
@@ -455,7 +455,6 @@ void Bar()
     t.Foo();
 }".WrapInCSharpClass("Type1");
             var source2 = @"public void Foo() { }".WrapInCSharpClass("Type2");
-
             var fixtest1 = @"private int i;
 void Bar()
 {

--- a/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/MakeMethodStaticTests.cs
@@ -8,6 +8,53 @@ namespace CodeCracker.Test.CSharp.Design
 {
     public class MakeMethodStaticTests : CodeFixVerifier<MakeMethodStaticAnalyzer, MakeMethodStaticCodeFixProvider>
     {
+        [Fact]
+        public async Task DontChangeOtherStaticMethods()
+        {
+            const string source = @"
+    class Bar
+    {
+        void ShouldBeStatic()
+        {
+        }
+        void Caller()
+        {
+            Foo.M(new Baz(ShouldBeStatic));
+        }
+    }
+    class Foo
+    {
+        public static void M(Baz b) { }
+    }
+    class Baz
+    {
+        public Baz(Action a)
+        {
+        }
+    }";
+            const string fixtest = @"
+    class Bar
+    {
+        static void ShouldBeStatic()
+        {
+        }
+        void Caller()
+        {
+            Foo.M(new Baz(ShouldBeStatic));
+        }
+    }
+    class Foo
+    {
+        public static void M(Baz b) { }
+    }
+    class Baz
+    {
+        public Baz(Action a)
+        {
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
 
         [Fact]
         public async Task MakeMethodStaticWithReferenceAsDelegateInDifferentDocs()


### PR DESCRIPTION
When a Method, that should be made static is used somewhere like `new  X().MethodToBecomeStatic();`. I fix it to `new X(); X.MethodToBecomeStatic()` to ensure that the program logic is not broken. 