### PR TITLE
Ignore Disposable Variable when object could live longer

### DIFF
--- a/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposableVariableNotDisposedAnalyzer.cs
@@ -107,15 +107,29 @@ namespace CodeCracker.CSharp.Usage
             var method = statement.FirstAncestorOrSelf<MethodDeclarationSyntax>();
             if (method == null) return false;
             if (IsReturned(method, statement, semanticModel, identitySymbol)) return true;
-            foreach (var childStatements in method.Body.DescendantNodes().OfType<StatementSyntax>())
+            foreach (var childStatement in method.Body.DescendantNodes().OfType<StatementSyntax>())
             {
-                if (childStatements.SpanStart > statement.SpanStart
-                && (IsCorrectDispose(childStatements as ExpressionStatementSyntax, semanticModel, identitySymbol)
-                || IsAssignedToField(childStatements as ExpressionStatementSyntax, semanticModel, identitySymbol)))
+                if (childStatement.SpanStart > statement.SpanStart
+                && (IsCorrectDispose(childStatement as ExpressionStatementSyntax, semanticModel, identitySymbol)
+                || IsPassedAsArgument(childStatement, semanticModel, identitySymbol)
+                || IsAssignedToFieldOrProperty(childStatement as ExpressionStatementSyntax, semanticModel, identitySymbol)))
                     return true;
             }
             return false;
         }
+
+        private static bool IsPassedAsArgument(StatementSyntax statement, SemanticModel semanticModel, ILocalSymbol identitySymbol)
+        {
+            if (statement == null) return false;
+            var args = statement.DescendantNodes().OfKind<ArgumentSyntax>(SyntaxKind.Argument);
+            foreach (var arg in args)
+            {
+                var argSymbol = semanticModel.GetSymbolInfo(arg.Expression).Symbol;
+                if (identitySymbol.Equals(argSymbol)) return true;
+            }
+            return false;
+        }
+
 
         private static bool IsReturned(MethodDeclarationSyntax method, StatementSyntax statement, SemanticModel semanticModel, ILocalSymbol identitySymbol)
         {
@@ -147,13 +161,13 @@ namespace CodeCracker.CSharp.Usage
             return isReturning;
         }
 
-        private static bool IsAssignedToField(ExpressionStatementSyntax expressionStatement, SemanticModel semanticModel, ILocalSymbol identitySymbol)
+        private static bool IsAssignedToFieldOrProperty(ExpressionStatementSyntax expressionStatement, SemanticModel semanticModel, ILocalSymbol identitySymbol)
         {
             if (expressionStatement == null) return false;
             if (!expressionStatement.Expression.IsKind(SyntaxKind.SimpleAssignmentExpression)) return false;
             var assignment = (AssignmentExpressionSyntax)expressionStatement.Expression;
             var assignmentTarget = semanticModel.GetSymbolInfo(assignment.Left).Symbol;
-            if (assignmentTarget?.Kind != SymbolKind.Field) return false;
+            if (assignmentTarget?.Kind != SymbolKind.Field && assignmentTarget?.Kind != SymbolKind.Property) return false;
             var assignmentSource = semanticModel.GetSymbolInfo(assignment.Right).Symbol;
             return (identitySymbol.Equals(assignmentSource));
         }

--- a/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposableVariableNotDisposedTests.cs
@@ -595,10 +595,10 @@ using (m = new System.IO.MemoryStream()) { }".WrapInCSharpMethod();
         public async Task FixADisposableDeclarationWithoutDisposeWithStatementsAfter()
         {
             var source = @"var m = new System.IO.MemoryStream();
-Console.WriteLine(m);".WrapInCSharpMethod();
+m.Flush();".WrapInCSharpMethod();
             var fixtest = @"using (var m = new System.IO.MemoryStream())
 {
-    Console.WriteLine(m);
+    m.Flush();
 }".WrapInCSharpMethod();
             await VerifyCSharpFixAsync(source, fixtest);
         }
@@ -609,14 +609,14 @@ Console.WriteLine(m);".WrapInCSharpMethod();
             var source = @"if (DateTime.Now.Second % 2 == 0)
 {
     var m = new System.IO.MemoryStream();
-    Console.WriteLine(m);
+    m.Flush();
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
             var fixtest = @"if (DateTime.Now.Second % 2 == 0)
 {
     using (var m = new System.IO.MemoryStream())
     {
-        Console.WriteLine(m);
+        m.Flush();
     }
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
@@ -682,11 +682,11 @@ using (m = new System.IO.MemoryStream())
         {
             var source = @"System.IO.MemoryStream m;
 m = new System.IO.MemoryStream();
-Console.WriteLine(m);".WrapInCSharpMethod();
+m.Flush();".WrapInCSharpMethod();
             var fixtest = @"System.IO.MemoryStream m;
 using (m = new System.IO.MemoryStream())
 {
-    Console.WriteLine(m);
+    m.Flush();
 }".WrapInCSharpMethod();
             await VerifyCSharpFixAsync(source, fixtest);
         }
@@ -932,7 +932,7 @@ using (m = new System.IO.MemoryStream())
 {
     System.IO.MemoryStream m;
     m = new System.IO.MemoryStream();
-    Console.WriteLine(m);
+    m.Flush();
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
             var fixtest = @"if (DateTime.Now.Second % 2 == 0)
@@ -940,7 +940,7 @@ Console.WriteLine(1);".WrapInCSharpMethod();
     System.IO.MemoryStream m;
     using (m = new System.IO.MemoryStream())
     {
-        Console.WriteLine(m);
+        m.Flush();
     }
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
@@ -954,7 +954,7 @@ Console.WriteLine(1);".WrapInCSharpMethod();
 if (DateTime.Now.Second % 2 == 0)
 {
     m = new System.IO.MemoryStream();
-    Console.WriteLine(m);
+    m.Flush();
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
             var fixtest = @"System.IO.MemoryStream m;
@@ -962,7 +962,7 @@ if (DateTime.Now.Second % 2 == 0)
 {
     using (m = new System.IO.MemoryStream())
     {
-        Console.WriteLine(m);
+        m.Flush();
     }
 }
 Console.WriteLine(1);".WrapInCSharpMethod();
@@ -976,7 +976,7 @@ Console.WriteLine(1);".WrapInCSharpMethod();
 if (DateTime.Now.Second % 2 == 0)
 {
     m = new System.IO.MemoryStream();
-    Console.WriteLine(m);
+    m.Flush();
 }
 m.Flush();
 Console.WriteLine(1);".WrapInCSharpMethod();
@@ -984,7 +984,7 @@ Console.WriteLine(1);".WrapInCSharpMethod();
 if (DateTime.Now.Second % 2 == 0)
 {
     m = new System.IO.MemoryStream();
-    Console.WriteLine(m);
+    m.Flush();
 }
 m.Flush();
 Console.WriteLine(1);
@@ -1005,7 +1005,7 @@ m.Dispose();".WrapInCSharpMethod();
                         if (DateTime.Now.Second % 2 == 0)
                         {
                             m = new Disposable();
-                            Console.WriteLine(m);
+                            m.Push();
                         }
                         m.Flush();
                         Console.WriteLine(1);
@@ -1015,6 +1015,7 @@ m.Dispose();".WrapInCSharpMethod();
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             const string fixtest = @"
@@ -1027,7 +1028,7 @@ m.Dispose();".WrapInCSharpMethod();
                         if (DateTime.Now.Second % 2 == 0)
                         {
                             m = new Disposable();
-                            Console.WriteLine(m);
+                            m.Push();
                         }
                         m.Flush();
                         Console.WriteLine(1);
@@ -1038,6 +1039,7 @@ m.Dispose();".WrapInCSharpMethod();
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             await VerifyCSharpFixAsync(source, fixtest);
@@ -1147,7 +1149,7 @@ using (var mem = new System.IO.MemoryStream())
                         if (DateTime.Now.Second % 2 == 0)
                         {
                             m = new Disposable();
-                            Console.WriteLine(m);
+                            m.Push();
                         }
                         m.Flush();
                         if (DateTime.Now.Second % 3 == 0)
@@ -1160,6 +1162,7 @@ using (var mem = new System.IO.MemoryStream())
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             const string fixtest = @"
@@ -1172,7 +1175,7 @@ using (var mem = new System.IO.MemoryStream())
                         if (DateTime.Now.Second % 2 == 0)
                         {
                             m = new Disposable();
-                            Console.WriteLine(m);
+                            m.Push();
                         }
                         m.Flush();
                         if (DateTime.Now.Second % 3 == 0)
@@ -1185,6 +1188,7 @@ using (var mem = new System.IO.MemoryStream())
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             await VerifyCSharpFixAsync(source, fixtest);
@@ -1205,7 +1209,7 @@ using (var mem = new System.IO.MemoryStream())
                             if (DateTime.Now.Second % 4 == 0)
                             {
                                 m = new Disposable();
-                                Console.WriteLine(m);
+                                m.Push();
                             }
                             m.Flush();
                         }
@@ -1219,6 +1223,7 @@ using (var mem = new System.IO.MemoryStream())
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             const string fixtest = @"
@@ -1233,7 +1238,7 @@ using (var mem = new System.IO.MemoryStream())
                             if (DateTime.Now.Second % 4 == 0)
                             {
                                 m = new Disposable();
-                                Console.WriteLine(m);
+                                m.Push();
                             }
                             m.Flush();
                         }
@@ -1247,6 +1252,7 @@ using (var mem = new System.IO.MemoryStream())
                 {
                     void IDisposable.Dispose() { }
                     public void Flush() { }
+                    public void Push() { }
                 }
 ";
             await VerifyCSharpFixAsync(source, fixtest);
@@ -1492,6 +1498,44 @@ class Foo
     }
 }";
             await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task IgnoreWhenPassedIntoMethod()
+        {
+            const string source = @"
+using System.IO;
+class Foo
+{
+    void Bar()
+    {
+        var m = new MemoryStream();
+        Baz(m);
+    }
+    void Baz(MemoryStream m) { }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
+        public async Task IgnoreWhenAssignedToField()
+        {
+            const string source = @"
+using System.IO;
+class HoldsDisposable
+{
+    public MemoryStream Ms { get; set; }
+}
+class Foo
+{
+    void Bar()
+    {
+        var m = new MemoryStream();
+        var h = new HoldsDisposable();
+        h.Ms = m;
+    }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
         }
     }
 }


### PR DESCRIPTION
Passed to methods.
Assigned to properties.
Fixes #465