### PR TITLE
Fix Make Ternary for VB when it has comments

### DIFF
--- a/src/VisualBasic/CodeCracker/Style/TernaryOperatorAnalyzer.vb
+++ b/src/VisualBasic/CodeCracker/Style/TernaryOperatorAnalyzer.vb
@@ -67,7 +67,6 @@ Namespace Style
 
             If TypeOf (ifClauseStatement) Is ReturnStatementSyntax AndAlso
             TypeOf (elseStatement) Is ReturnStatementSyntax Then
-
                 Dim diag = Diagnostic.Create(RuleForIfWithReturn, ifStatement.IfKeyword.GetLocation, "You can use a ternary operator.")
                 context.ReportDiagnostic(diag)
                 Exit Sub
@@ -76,7 +75,10 @@ Namespace Style
             Dim ifAssignment = TryCast(ifClauseStatement, AssignmentStatementSyntax)
             Dim elseAssignment = TryCast(elseStatement, AssignmentStatementSyntax)
             If ifAssignment Is Nothing OrElse elseAssignment Is Nothing Then Exit Sub
-            If Not ifAssignment?.Left.IsEquivalentTo(elseAssignment?.Left) Then Exit Sub
+            Dim semanticModel = context.SemanticModel
+            Dim ifSymbol = semanticModel.GetSymbolInfo(ifAssignment.Left).Symbol
+            Dim elseSymbol = semanticModel.GetSymbolInfo(elseAssignment.Left).Symbol
+            If ifSymbol Is Nothing OrElse elseSymbol Is Nothing OrElse ifSymbol.Equals(elseSymbol) = False Then Exit Sub
             Dim assignDiag = Diagnostic.Create(RuleForIfWithAssignment, ifStatement.IfKeyword.GetLocation(), "You can use a ternary operator.")
             context.ReportDiagnostic(assignDiag)
         End Sub

--- a/src/VisualBasic/CodeCracker/Style/TernaryOperatorCodeFixProviders.vb
+++ b/src/VisualBasic/CodeCracker/Style/TernaryOperatorCodeFixProviders.vb
@@ -49,8 +49,8 @@ Namespace Style
                 EnsureNothingAsType(semanticModel, type, typeSyntax)
 
             Dim leadingTrivia = ifBlock.GetLeadingTrivia()
-            leadingTrivia = leadingTrivia.InsertRange(leadingTrivia.Count - 1, ifReturn.GetLeadingTrivia().Where(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia)))
-            leadingTrivia = leadingTrivia.InsertRange(leadingTrivia.Count - 1, elseReturn.GetLeadingTrivia().Where(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia)))
+            leadingTrivia = leadingTrivia.InsertRange(leadingTrivia.Count - 1, ifReturn.GetLeadingTrivia())
+            leadingTrivia = leadingTrivia.InsertRange(leadingTrivia.Count - 1, elseReturn.GetLeadingTrivia())
 
             Dim trailingTrivia = ifBlock.GetTrailingTrivia.
                 InsertRange(0, elseReturn.GetTrailingTrivia().Where(Function(trivia) Not trivia.IsKind(SyntaxKind.EndOfLineTrivia))).

--- a/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
@@ -319,8 +319,10 @@ Public Class MyType
     Public Sub Foo()
         Dim a As Integer
         If True Then
+            ' a
             a = 1 ' One Thing
         Else
+            ' b
             a = 2 ' Another
         End If
     End Sub
@@ -330,6 +332,8 @@ End Class"
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer
+        ' a
+        ' b
         a = If(True, 1, 2) ' One Thing ' Another
     End Sub
 End Class"

--- a/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
@@ -1,11 +1,12 @@
 ﻿Imports CodeCracker.VisualBasic.Style
 Imports Xunit
 
-Public Class TernaryOperatorWithAssignmentTests
-    Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorWithAssignmentCodeFixProvider)
+Namespace Style
+    Public Class TernaryOperatorWithAssignmentTests
+        Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorWithAssignmentCodeFixProvider)
 
-    Public Async Function WhenUsingIfWithoutElseAnalyzerDoesNotCreateDiagnostic() As Task
-        Const sourceWithoutElse = "
+        Public Async Function WhenUsingIfWithoutElseAnalyzerDoesNotCreateDiagnostic() As Task
+            Const sourceWithoutElse = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -17,12 +18,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithoutElse)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithoutElse)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnIfAnalyzerDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnIfAnalyzerDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -37,12 +38,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnElseAnalyzerDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnElseAnalyzerDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -57,12 +58,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithoutReturnOnElseDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithoutReturnOnElseDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -77,12 +78,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButIfBlockWithoutReturnDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButIfBlockWithoutReturnDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -97,12 +98,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIElseIfDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIElseIfDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -117,12 +118,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfElseIfElseDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfElseIfElseDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -137,21 +138,21 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithDirectReturnAnalyzerCreatesDiagnostic() As Task
-        Dim expected As New DiagnosticResult With {
-            .Id = DiagnosticId.TernaryOperator_Assignment.ToDiagnosticId(),
-            .Message = "You can use a ternary operator.",
-            .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
-            .Locations = {New DiagnosticResultLocation("Test0.vb", 8, 13)}
-            }
-        Await VerifyBasicDiagnosticAsync(sourceAssign, expected)
-    End Function
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithDirectReturnAnalyzerCreatesDiagnostic() As Task
+            Dim expected As New DiagnosticResult With {
+                .Id = DiagnosticId.TernaryOperator_Assignment.ToDiagnosticId(),
+                .Message = "You can use a ternary operator.",
+                .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
+                .Locations = {New DiagnosticResultLocation("Test0.vb", 8, 13)}
+                }
+            Await VerifyBasicDiagnosticAsync(sourceAssign, expected)
+        End Function
 
-    Private Const sourceAssign = "
+        Private Const sourceAssign = "
 Imports System
 Namespace ConsoleApplication1
     Class MyType
@@ -167,9 +168,9 @@ Namespace ConsoleApplication1
     End Class
 End Namespace"
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithAssignmentChangeToTernaryFix() As Task
-        Const fix = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithAssignmentChangeToTernaryFix() As Task
+            Const fix = "
 Imports System
 Namespace ConsoleApplication1
     Class MyType
@@ -180,12 +181,21 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicFixAsync(sourceAssign, fix)
-    End Function
+            Await VerifyBasicFixAsync(sourceAssign, fix)
+        End Function
+        Sub Foo()
+            Dim v As Boolean
+            If True Then
+                ' a comment
+                v = False
+            Else
+                v = True
+            End If
+        End Sub
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithAssignmentChangeToTernaryFixAll() As Task
-        Const fix = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithAssignmentChangeToTernaryFixAll() As Task
+            Const fix = "
 Imports System
 Namespace ConsoleApplication1
     Class MyType
@@ -196,12 +206,12 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicFixAllAsync(New String() {sourceAssign, sourceAssign.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {sourceAssign, sourceAssign.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
-    <Fact>
-    Public Async Function WhenTernaryWithObjectDoesApplyFix() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenTernaryWithObjectDoesApplyFix() As Task
+            Const source = "
 Class MyCustomer
     Public Property Value As String
 End Class
@@ -221,7 +231,7 @@ Class Tester
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class MyCustomer
     Public Property Value As String
 End Class
@@ -237,13 +247,13 @@ Class Tester
     End Sub
 End Class"
 
-        Await VerifyBasicFixAsync(source, fix)
+            Await VerifyBasicFixAsync(source, fix)
 
-    End Function
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFix() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFix() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer?
@@ -255,7 +265,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer?
@@ -263,13 +273,13 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
-    <Fact>
-    Public Async Function FixConsidersBaseTypeAssignent() As Task
-        Const source = "
+        <Fact>
+        Public Async Function FixConsidersBaseTypeAssignent() As Task
+            Const source = "
 Public Class Base
 End Class
 Public Class B
@@ -286,7 +296,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class Base
 End Class
 Public Class B
@@ -299,12 +309,12 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
-    <Fact>
-    Public Async Function WhenUsingCommentsConcatenateAtEndOfTernary() As Task
-        Const source = "
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
+        <Fact>
+        Public Async Function WhenUsingCommentsConcatenateAtEndOfTernary() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer
@@ -316,7 +326,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer
@@ -324,13 +334,13 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFixAll() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithNullableValueTypeAssignmentChangeToTernaryFixAll() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer?
@@ -342,7 +352,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim a As Integer?
@@ -350,24 +360,24 @@ Public Class MyType
     End Sub
 End Class"
 
-        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingConcatenationAssignmentExpandsToConcatenateAtEndOfTernary() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingConcatenationAssignmentExpandsToConcatenateAtEndOfTernary() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim x = ""test""
         If True Then
-            x = ""1"" 
+            x = ""1""
         Else
             x &= ""2""
         End If
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim x = ""test""
@@ -375,14 +385,14 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
 
-    <Fact>
-    Public Async Function WhenUsingAddAssiginmentExpandsOperationProperly() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingAddAssiginmentExpandsOperationProperly() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim x = 0
@@ -394,7 +404,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim x = 0
@@ -402,13 +412,13 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingSubtractAssiginmentExpandsOperationProperly() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingSubtractAssiginmentExpandsOperationProperly() As Task
+            Const source = "
 Public Class MyType
     Public Sub Foo()
         Dim x = 0
@@ -420,7 +430,7 @@ Public Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Sub Foo()
         Dim x = 0
@@ -428,13 +438,13 @@ Public Class MyType
     End Sub
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingAssignmentOperatorReturnSameAssignment() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingAssignmentOperatorReturnSameAssignment() As Task
+            Const source = "
 Class MyType
     Public Sub x2()
             Dim output As String = String.Empty
@@ -448,7 +458,7 @@ Class MyType
         End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class MyType
     Public Sub x2()
             Dim output As String = String.Empty
@@ -458,18 +468,16 @@ Class MyType
         End Sub
 End Class"
 
-        Await VerifyBasicFixAsync(source, fix, formatBeforeCompare:=True)
-    End Function
+            Await VerifyBasicFixAsync(source, fix, formatBeforeCompare:=True)
+        End Function
+    End Class
 
+    Public Class TernaryOperatorWithReturnTests
+        Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorWithReturnCodeFixProvider)
 
-End Class
-
-Public Class TernaryOperatorWithReturnTests
-    Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorWithReturnCodeFixProvider)
-
-    <Fact>
-    Public Async Function WhenUsingIfWithoutElseAnalyzerDoesNotCreateDiagnostic() As Task
-        Const sourceWithoutElse = "
+        <Fact>
+        Public Async Function WhenUsingIfWithoutElseAnalyzerDoesNotCreateDiagnostic() As Task
+            Const sourceWithoutElse = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -480,12 +488,12 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithoutElse)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithoutElse)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnIfAnalyzerDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnIfAnalyzerDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -499,12 +507,12 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnElseAnalyzerDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithBlockWith2StatementsOnElseAnalyzerDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -518,12 +526,12 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButWithoutReturnOnElseDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButWithoutReturnOnElseDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -536,12 +544,12 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfWithElseButIfBlockWithoutReturnDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfWithElseButIfBlockWithoutReturnDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -554,12 +562,12 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIElseIfDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIElseIfDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Function Foo() As Integer
@@ -573,13 +581,13 @@ Namespace ConsoleApplication1
         End Function
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFix() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFix() As Task
+            Const source = "
 Public Class MyType
     Public Function Foo() As Integer?
         If True Then
@@ -590,20 +598,20 @@ Public Class MyType
     End Function
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Function Foo() As Integer?
         Return If(True, 1, DirectCast(Nothing, Integer?))
     End Function
 End Class"
 
-        ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
-        Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
-    End Function
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfElseIfElseDoesNotCreate() As Task
-        Const sourceWithMultipleStatements = "
+        <Fact>
+        Public Async Function WhenUsingIfElseIfElseDoesNotCreate() As Task
+            Const sourceWithMultipleStatements = "
 Namespace ConsoleApplication1
     Class TypeName
         Public Sub Foo()
@@ -617,13 +625,13 @@ Namespace ConsoleApplication1
         End Sub
     End Class
 End Namespace"
-        Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(sourceWithMultipleStatements)
+        End Function
 
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFixAll() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithNullableValueTypeDirectReturnChangeToTernaryFixAll() As Task
+            Const source = "
 Public Class MyType
     Public Function Foo() As Integer?
         If True Then
@@ -634,17 +642,17 @@ Public Class MyType
     End Function
 End Class"
 
-        Const fix = "
+            Const fix = "
 Public Class MyType
     Public Function Foo() As Integer?
         Return If(True, 1, DirectCast(Nothing, Integer?))
     End Function
 End Class"
 
-        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
-    Private Const sourceReturn = "
+        Private Const sourceReturn = "
 Namespace ConsoleApplication1
     Class MyType
         Public Function Foo() As Integer
@@ -658,20 +666,20 @@ Namespace ConsoleApplication1
     End Class
 End Namespace"
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithDirectReturnAnalyzerCreatesDiagnostic() As Task
-        Dim expected As New DiagnosticResult With {
-            .Id = DiagnosticId.TernaryOperator_Return.ToDiagnosticId(),
-            .Message = "You can use a ternary operator.",
-            .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
-            .Locations = {New DiagnosticResultLocation("Test0.vb", 6, 13)}
-            }
-        Await VerifyBasicDiagnosticAsync(sourceReturn, expected)
-    End Function
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithDirectReturnAnalyzerCreatesDiagnostic() As Task
+            Dim expected As New DiagnosticResult With {
+                .Id = DiagnosticId.TernaryOperator_Return.ToDiagnosticId(),
+                .Message = "You can use a ternary operator.",
+                .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
+                .Locations = {New DiagnosticResultLocation("Test0.vb", 6, 13)}
+                }
+            Await VerifyBasicDiagnosticAsync(sourceReturn, expected)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithDirectReturnCreatesFix() As Task
-        Const fix = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithDirectReturnCreatesFix() As Task
+            Const fix = "
 Namespace ConsoleApplication1
     Class MyType
         Public Function Foo() As Integer
@@ -681,12 +689,12 @@ Namespace ConsoleApplication1
     End Class
 End Namespace"
 
-        Await VerifyBasicFixAsync(sourceReturn, fix)
-    End Function
+            Await VerifyBasicFixAsync(sourceReturn, fix)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIfAndElseWithDirectReturnCreatesFixAll() As Task
-        Const fix = "
+        <Fact>
+        Public Async Function WhenUsingIfAndElseWithDirectReturnCreatesFixAll() As Task
+            Const fix = "
 Namespace ConsoleApplication1
     Class MyType
         Public Function Foo() As Integer
@@ -696,18 +704,73 @@ Namespace ConsoleApplication1
     End Class
 End Namespace"
 
-        Await VerifyBasicFixAllAsync(New String() {sourceReturn, sourceReturn.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {sourceReturn, sourceReturn.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
+        <Fact>
+        Public Async Function FixCanWorkWithCommentsOnIf() As Task
+            Const source = "
+Function s() As Boolean
+    If True Then
+        ' a comment
+        Return False 'b comment
+    Else
+        Return True
+    End If
+End Function"
+            Const fix = "
+Function s() As Boolean
+    ' a comment
+    Return If(True, False, True) 'b comment
+End Function"
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
 
-End Class
+        Public Async Function FixCanWorkWithCommentsOnElse() As Task
+            Const source = "
+Function s() As Boolean
+    If True Then
+        Return False
+    Else
+        ' a comment
+        Return True 'b comment
+    End If
+End Function"
+            Const fix = "
+Function s() As Boolean
+    ' a comment
+    Return If(True, False, True) 'b comment
+End Function"
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
 
-Public Class TernaryOperatorFromIifTests
-    Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorFromIifCodeFixProvider)
+        Public Async Function FixCanWorkWithCommentsOnIfAndElse() As Task
+            Const source = "
+Function s() As Boolean
+    If True Then
+        ' a comment
+        Return False 'b comment
+    Else
+        ' c comment
+        Return True 'd comment
+    End If
+End Function"
+            Const fix = "
+Function s() As Boolean
+    ' a comment
+    ' c comment
+    Return If(True, False, True) 'b comment 'd comment
+End Function"
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
+    End Class
 
-    <Fact>
-    Public Async Function WhenUsingIifAndSimpleAssignmentCreatesFix() As Task
-        Const source = "
+    Public Class TernaryOperatorFromIifTests
+        Inherits CodeFixVerifier(Of TernaryOperatorAnalyzer, TernaryOperatorFromIifCodeFixProvider)
+
+        <Fact>
+        Public Async Function WhenUsingIifAndSimpleAssignmentCreatesFix() As Task
+            Const source = "
 Class TypeName
     Public Sub Foo()
         Dim x = 1
@@ -715,7 +778,7 @@ Class TypeName
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class TypeName
     Public Sub Foo()
         Dim x = 1
@@ -723,12 +786,12 @@ Class TypeName
     End Sub
 End Class"
 
-        Await VerifyBasicFixAsync(source, fix)
-    End Function
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIifAndSimpleAssignmentCreatesFixAll() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIifAndSimpleAssignmentCreatesFixAll() As Task
+            Const source = "
 Class MyType
     Public Sub Foo()
         Dim x = 1
@@ -736,7 +799,7 @@ Class MyType
     End Sub
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class MyType
     Public Sub Foo()
         Dim x = 1
@@ -744,12 +807,12 @@ Class MyType
     End Sub
 End Class"
 
-        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIifAndReturnCreatesFix() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIifAndReturnCreatesFix() As Task
+            Const source = "
 Class MyType
     Public Function Foo() As Integer
         Dim x = 1
@@ -757,7 +820,7 @@ Class MyType
     End Function
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class MyType
     Public Function Foo() As Integer
         Dim x = 1
@@ -765,20 +828,20 @@ Class MyType
     End Function
 End Class"
 
-        Dim expected As New DiagnosticResult With {
-            .Id = DiagnosticId.TernaryOperator_Iif.ToDiagnosticId(),
-            .Message = "You can use a ternary operator.",
-            .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
-            .Locations = {New DiagnosticResultLocation("Test0.vb", 5, 16)}
-            }
+            Dim expected As New DiagnosticResult With {
+                .Id = DiagnosticId.TernaryOperator_Iif.ToDiagnosticId(),
+                .Message = "You can use a ternary operator.",
+                .Severity = Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
+                .Locations = {New DiagnosticResultLocation("Test0.vb", 5, 16)}
+                }
 
-        Await VerifyBasicDiagnosticAsync(source, expected)
-        Await VerifyBasicFixAsync(source, fix)
-    End Function
+            Await VerifyBasicDiagnosticAsync(source, expected)
+            Await VerifyBasicFixAsync(source, fix)
+        End Function
 
-    <Fact>
-    Public Async Function WhenUsingIifAndReturnCreatesFixAll() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenUsingIifAndReturnCreatesFixAll() As Task
+            Const source = "
 Class MyType
     Public Function Foo() As Integer
         Dim x = 1
@@ -786,7 +849,7 @@ Class MyType
     End Function
 End Class"
 
-        Const fix = "
+            Const fix = "
 Class MyType
     Public Function Foo() As Integer
         Dim x = 1
@@ -794,44 +857,44 @@ Class MyType
     End Function
 End Class"
 
-        Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
-    End Function
+            Await VerifyBasicFixAllAsync(New String() {source, source.Replace("MyType", "MyType1")}, New String() {fix, fix.Replace("MyType", "MyType1")})
+        End Function
 
-    <Fact>
-    Public Async Function WhenNotUsingIifDoesNotCreateAnalyzer() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenNotUsingIifDoesNotCreateAnalyzer() As Task
+            Const source = "
 Class TypeName
     Public Sub Foo()
         Dim x = 1
     End Sub
 End Class"
 
-        Await VerifyBasicHasNoDiagnosticsAsync(source)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
 
-    <Fact>
-    Public Async Function WhenIifWithTooManyParametersDoesNotCreateAnalyzer() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenIifWithTooManyParametersDoesNotCreateAnalyzer() As Task
+            Const source = "
 Class TypeName
     Public Sub Foo()
         Dim x = Iif(true, 1, 2, 3)
     End Sub
 End Class"
 
-        Await VerifyBasicHasNoDiagnosticsAsync(source)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
 
-    <Fact>
-    Public Async Function WhenIifWithTooFewParametersDoesNotCreateAnalyzer() As Task
-        Const source = "
+        <Fact>
+        Public Async Function WhenIifWithTooFewParametersDoesNotCreateAnalyzer() As Task
+            Const source = "
 Class TypeName
     Public Sub Foo()
         Dim x = Iif(true, 1)
     End Sub
 End Class"
 
-        Await VerifyBasicHasNoDiagnosticsAsync(source)
-    End Function
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
 
-End Class
-
+    End Class
+End Namespace


### PR DESCRIPTION
Closes #725 for CC0013
Also enables it to work with ternaries when they have leading trivia.
Also added the missing namespace to the test file.