### PR TITLE
Respect precendence rules when nesting if statements

### DIFF
--- a/src/CSharp/CodeCracker/Refactoring/MergeNestedIfCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Refactoring/MergeNestedIfCodeFixProvider.cs
@@ -40,8 +40,11 @@ namespace CodeCracker.CSharp.Refactoring
         private static SyntaxNode MergeIfs(IfStatementSyntax ifStatement, SyntaxNode root)
         {
             var nestedIf = (IfStatementSyntax)ifStatement.Statement.GetSingleStatementFromPossibleBlock();
+            var nestedCondition = nestedIf.Condition;
+            if (nestedCondition.IsAnyKind(SyntaxKind.LogicalOrExpression, SyntaxKind.ConditionalExpression, SyntaxKind.CoalesceExpression))
+                nestedCondition = SyntaxFactory.ParenthesizedExpression(nestedCondition);
             var newIf = ifStatement
-                .WithCondition(SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, ifStatement.Condition, nestedIf.Condition))
+                .WithCondition(SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, ifStatement.Condition, nestedCondition))
                 .WithStatement(nestedIf.Statement)
                 .WithLeadingTrivia(ifStatement.GetLeadingTrivia().AddRange(nestedIf.GetLeadingTrivia()))
                 .WithAdditionalAnnotations(Formatter.Annotation);

--- a/test/CSharp/CodeCracker.Test/Refactoring/MergeNestedIfTest.cs
+++ b/test/CSharp/CodeCracker.Test/Refactoring/MergeNestedIfTest.cs
@@ -185,5 +185,70 @@ namespace CodeCracker.Test.CSharp.Refactoring
                     var a = 1;//comment2".WrapInCSharpMethod();
             await VerifyCSharpFixAsync(test, fixtest);
         }
+
+        [Fact]
+        public async Task FixAddsParenthesisWhenSecondConditionHasLogicalORExpression()
+        {
+            var test = @"
+var conditionA = false;
+var conditionB = false;
+var conditionC = false;
+if (conditionA)
+    if (conditionB || conditionC)
+        System.Console.WriteLine();
+".WrapInCSharpMethod();
+            var fixtest = @"
+var conditionA = false;
+var conditionB = false;
+var conditionC = false;
+if (conditionA && (conditionB || conditionC))
+    System.Console.WriteLine();
+".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(test, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAddsParenthesisWhenSecondConditionHasConditionalExpression()
+        {
+            var test = @"
+var conditionA = false;
+var conditionB = false;
+var conditionC = false;
+var conditionD = false;
+if (conditionA)
+    if (conditionB ? conditionC : conditionD)
+        System.Console.WriteLine();
+".WrapInCSharpMethod();
+            var fixtest = @"
+var conditionA = false;
+var conditionB = false;
+var conditionC = false;
+var conditionD = false;
+if (conditionA && (conditionB ? conditionC : conditionD))
+    System.Console.WriteLine();
+".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(test, fixtest);
+        }
+
+        [Fact]
+        public async Task FixAddsParenthesisWhenSecondConditionHasCoalescingExpression()
+        {
+            var test = @"
+var conditionA = false;
+bool? conditionB = false;
+var conditionC = false;
+if (conditionA)
+    if (conditionB ?? conditionC)
+        System.Console.WriteLine();
+".WrapInCSharpMethod();
+            var fixtest = @"
+var conditionA = false;
+bool? conditionB = false;
+var conditionC = false;
+if (conditionA && (conditionB ?? conditionC))
+    System.Console.WriteLine();
+".WrapInCSharpMethod();
+            await VerifyCSharpFixAsync(test, fixtest);
+        }
     }
 }


### PR DESCRIPTION
Closes #740
Fixing for Logical OR, Conditional and Coalescing.