### PR TITLE
Enable attributes when ignoring private methods in VB

### DIFF
--- a/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/RemovePrivateMethodNeverUsedAnalyzer.cs
@@ -58,7 +58,17 @@ namespace CodeCracker.CSharp.Usage
                 foreach (var attribute in attributeList.Attributes)
                 {
                     var identifierName = attribute.Name as IdentifierNameSyntax;
-                    var nameText = identifierName?.Identifier.Text;
+                    string nameText = null;
+                    if (identifierName != null)
+                    {
+                        nameText = identifierName?.Identifier.Text;
+                    }
+                    else
+                    {
+                        var qualifiedName = attribute.Name as QualifiedNameSyntax;
+                        if (qualifiedName != null)
+                            nameText = qualifiedName.Right?.Identifier.Text;
+                    }
                     if (nameText == null) continue;
                     if (IsExcludedAttributeName(nameText)) return true;
                 }

--- a/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.cs
@@ -9,6 +9,7 @@ namespace CodeCracker.Test.CSharp.Usage
         [Theory]
         [InlineData("Fact")]
         [InlineData("ContractInvariantMethod")]
+        [InlineData("System.Diagnostics.Contracts.ContractInvariantMethod")]
         [InlineData("DataMember")]
         public async void DoesNotGenerateDiagnosticsWhenMethodAttributeIsAnException(string value)
         {

--- a/test/VisualBasic/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.vb
+++ b/test/VisualBasic/CodeCracker.Test/Usage/RemovePrivateMethodNeverUsedAnalyzerTest.vb
@@ -5,6 +5,53 @@ Namespace Usage
     Public Class RemovePrivateMethodNeverUsedAnalyzerTest
         Inherits CodeFixVerifier(Of RemovePrivateMethodNeverUsedAnalyzer, RemovePrivateMethodNeverUsedCodeFixProvider)
 
+        <Theory>
+        <InlineData("Fact")>
+        <InlineData("ContractInvariantMethod")>
+        <InlineData("System.Diagnostics.Contracts.ContractInvariantMethod")>
+        <InlineData("DataMember")>
+        Public Async Function DoesNotGenerateDiagnosticsWhenMethodAttributeIsAnException(value As String) As Task
+            Dim source = "
+Class Foo
+    <" + value + ">
+    Private Sub PrivateFoo()
+    End Sub
+End Class"
+            Await VerifyBasicHasNoDiagnosticsAsync(source)
+        End Function
+
+        <Fact>
+        Public Async Function MainMethodEntryPointReturningVoidDoesNotCreateDiagnostic() As Task
+            Const test = "
+Module Foo
+    Sub Main(args as String())
+    End Sub
+End Module"
+            Await VerifyBasicHasNoDiagnosticsAsync(test)
+        End Function
+
+        <Fact>
+        Public Async Function MainMethodEntryPointReturningIntegerDoesNotCreateDiagnostic() As Task
+            Const test = "
+Module Foo
+    Function Main(args as String()) as Integer
+        Return 0
+    End Function
+End Module"
+            Await VerifyBasicHasNoDiagnosticsAsync(test)
+        End Function
+
+        <Fact>
+        Public Async Function MainMethodEntryPointWithoutParameterDoesNotCreateDiagnostic() As Task
+            Const test = "
+Module Foo
+    Function Main() as Integer
+        Return 0
+    End Function
+End Module"
+            Await VerifyBasicHasNoDiagnosticsAsync(test)
+        End Function
+
         <Fact>
         Public Async Function DoesNotGenerateDiagnostics() As Task
             Const test = "


### PR DESCRIPTION
Fixes #744
Also, fixes on C# when qualified names were not verified
Also, check for entry points in VB (already worked, only tests)