### PR TITLE
Fix 'GC.SuppressFinalize within the finally block' #776

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
@@ -1,4 +1,5 @@
-﻿using CodeCracker.CSharp.Usage;
+﻿using System;
+using CodeCracker.CSharp.Usage;
 using Microsoft.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;
@@ -56,6 +57,27 @@ namespace CodeCracker.Test.CSharp.Usage
             };
 
             await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async void DoNotWarnIfClassImplementsIDisposableWithSuppressFinalizeCallInFinally()
+        {
+            const string test = @"
+                public class MyType : System.IDisposable
+                {
+                    public void Dispose()
+                    {
+                        try
+                        {
+                        }
+                        finally
+                        {
+                            System.GC.SuppressFinalize(this);
+                        }
+                    }
+                }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #776 

DisposablesShouldCallSuppressFinalizeAnalyzer did not find GC.SuppressFinalize(this) in finally block. 
I added proper test DoNotWarnIfClassImplementsIDisposableWithSuppressFinalizeCallInFinally() to check this issue.