### PR TITLE
Fix 'GC.SuppressFinalize within the finally block' #776

### DIFF
--- a/src/CSharp/CodeCracker/Usage/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/DisposablesShouldCallSuppressFinalizeAnalyzer.cs
@@ -56,7 +56,7 @@ namespace CodeCracker.CSharp.Usage
             if (symbol.IsSealed && !ContainsUserDefinedFinalizer(symbol)) return;
             if (!ContainsNonPrivateConstructors(symbol)) return;
 
-            var statements = method.Body?.Statements.OfType<ExpressionStatementSyntax>();
+            var statements = method.Body?.DescendantNodes().OfType<ExpressionStatementSyntax>();
             if (statements != null)
             {
                 foreach (var statement in statements)

--- a/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/DisposablesShouldCallSuppressFinalizeTests.cs
@@ -59,6 +59,66 @@ namespace CodeCracker.Test.CSharp.Usage
         }
 
         [Fact]
+        public async void DoNotWarnIfClassImplementsIDisposableWithSuppressFinalizeCallInFinally()
+        {
+            const string test = @"
+                 public class MyType : System.IDisposable
+                 {
+                     public void Dispose()
+                     {
+                         try
+                         {
+                         }
+                         finally
+                         {
+                             System.GC.SuppressFinalize(this);
+                         }
+                     }
+                 }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async void DoNotWarnIfClassImplementsIDisposableWithSuppressFinalizeCallInIf()
+        {
+            const string test = @"
+                 public class MyType : System.IDisposable
+                 {
+                     public void Dispose()
+                     {
+                         if (true)
+                         {
+                             System.GC.SuppressFinalize(this);
+                         }
+                     }
+                 }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async void DoNotWarnIfClassImplementsIDisposableWithSuppressFinalizeCallInElse()
+        {
+            const string test = @"
+                 public class MyType : System.IDisposable
+                 {
+                     public void Dispose()
+                     {
+                         if (true)
+                         {
+                         }
+                         else
+                         {
+                             System.GC.SuppressFinalize(this);
+                         }
+                     }
+                 }";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
         public async Task NoWarningIfClassImplementsDisposableCallsSuppressFinalizeAndCallsDisposeWithThis()
         {
             const string source = @"


### PR DESCRIPTION
Fixes #776

DisposablesShouldCallSuppressFinalizeAnalyzer did not find GC.SuppressFinalize(this) in code blocks. Now it checks for GC.SuppressFinalize(this) in any block - finally/if etc.
I added proper tests to check this issue.
