### PR TITLE
CC0122 Replace Task.Result with await Task

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -46,6 +46,8 @@
     <Compile Include="Design\InconsistentAccessibility\InconsistentAccessibilityInPropertyType.cs" />
     <Compile Include="Design\MakeMethodStaticAnalyzer.cs" />
     <Compile Include="Design\MakeMethodStaticCodeFixProvider.cs" />
+    <Compile Include="Design\ResultInAsyncAnalyzer.cs" />
+    <Compile Include="Design\ResultInAsyncCodeFixProvider.cs" />
     <Compile Include="Extensions\CSharpAnalyzerExtensions.cs" />
     <Compile Include="Extensions\CSharpGeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Extensions\InitializerState.cs" />

--- a/src/CSharp/CodeCracker/Design/ResultInAsyncAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/ResultInAsyncAnalyzer.cs
@@ -1,0 +1,66 @@
+﻿using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace CodeCracker.CSharp.Design
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ResultInAsyncAnalyzer : DiagnosticAnalyzer
+    {
+        internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ResultInAsyncAnalyzer_Title), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.ResultInAsync_MessageFormat), Resources.ResourceManager, typeof(Resources));
+        internal static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ResultInAsync_Description), Resources.ResourceManager, typeof(Resources));
+        internal const string Category = SupportedCategories.Design;
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId.ResultInAsync.ToDiagnosticId(),
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            true,
+            description: Description,
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.ResultInAsync));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) =>
+            context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.InvocationExpression);
+
+        private static void Analyzer(SyntaxNodeAnalysisContext context)
+        {
+            if (context.IsGenerated()) return;
+            var invocation = (InvocationExpressionSyntax)context.Node;
+            var parentMethod = invocation.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+            if (parentMethod == null) return;
+            var parentIsAsync = parentMethod.Modifiers.Any(n => n.IsKind(SyntaxKind.AsyncKeyword));
+            if (!parentIsAsync) return;
+            // We now know that we are in async method
+
+            var memberAccess = invocation.Parent as MemberAccessExpressionSyntax;
+            if (memberAccess == null) return;
+            var member = memberAccess.Name;
+            if (member.ToString() != "Result") return;
+            // We now know that we are accessing .Result
+
+            var identifierSymbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
+            if (identifierSymbol.OriginalDefinition.ToString() != "System.Threading.Tasks.Task<TResult>.Result") return;
+            // We now know that we are accessing System.Threading.Tasks.Task<TResult>.Result
+
+            SimpleNameSyntax identifier;
+            identifier = invocation.Expression as IdentifierNameSyntax;
+            if (identifier == null)
+            {
+                var transient = invocation.Expression as MemberAccessExpressionSyntax;
+                identifier = transient.Name;
+            }
+            if (identifier == null) return; // It's not supposed to happen. Don't throw an exception, though.
+            context.ReportDiagnostic(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.Identifier.Text));
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Design/ResultInAsyncCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Design/ResultInAsyncCodeFixProvider.cs
@@ -1,0 +1,75 @@
+﻿using CodeCracker.Properties;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodeCracker.CSharp.Design
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ResultInAsyncCodeFixProvider)), Shared]
+    public class ResultInAsyncCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticId.ResultInAsync.ToDiagnosticId());
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public async sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            var compilation = (CSharpCompilation)await context.Document.Project.GetCompilationAsync();
+            context.RegisterCodeFix(CodeAction.Create(
+                Resources.ResultInAsyncCodeFixProvider_Title,
+                ct => ReplaceResultWithAwaitAsync(context.Document, diagnostic, ct),
+                nameof(ResultInAsyncCodeFixProvider)
+               ), diagnostic);
+        }
+
+        private async static Task<Document> ReplaceResultWithAwaitAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false));
+            var sourceSpan = diagnostic.Location.SourceSpan;
+            var invocation = root.FindToken(sourceSpan.Start).Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
+            var memberAccess = invocation.Parent as MemberAccessExpressionSyntax;
+
+            // Replace memberAccess with the async invocation
+            SyntaxNode newRoot;
+
+            // See if the member access expression is a part of something bigger
+            // i.e. something.Result.something. Then we need to produce (await something.Result).something
+            var parentAccess = memberAccess.Parent as MemberAccessExpressionSyntax;
+            if (parentAccess != null)
+            {
+                var rewritten =
+                    SyntaxFactory.ParenthesizedExpression(
+                        SyntaxFactory.AwaitExpression(
+                            invocation)
+                        )
+                    .WithLeadingTrivia(invocation.GetLeadingTrivia())
+                    .WithTrailingTrivia(invocation.GetTrailingTrivia());
+                var subExpression = parentAccess.Expression;
+                newRoot = root.ReplaceNode(subExpression, rewritten);
+            }
+            else
+            {
+                var rewritten =
+                    SyntaxFactory.AwaitExpression(
+                        invocation)
+                    .WithLeadingTrivia(invocation.GetLeadingTrivia())
+                    .WithTrailingTrivia(invocation.GetTrailingTrivia());
+                newRoot = root.ReplaceNode(memberAccess, rewritten);
+            }
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -80,5 +80,6 @@
         NameOf_External = 108,
         StringFormatArgs_ExtraArgs = 111,
         AlwaysUseVarOnPrimitives = 105,
+        ResultInAsync = 122,
     }
 }

--- a/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
+++ b/src/Common/CodeCracker.Common/Properties/Resources.Designer.cs
@@ -260,6 +260,42 @@ namespace CodeCracker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Calling Task.Result in an awaited method may lead to a deadlock. Obtain the result of the task with the await keyword to avoid deadlocks..
+        /// </summary>
+        public static string ResultInAsync_Description {
+            get {
+                return ResourceManager.GetString("ResultInAsync_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to await &apos;{0}&apos; rather than calling its Result..
+        /// </summary>
+        public static string ResultInAsync_MessageFormat {
+            get {
+                return ResourceManager.GetString("ResultInAsync_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace Task.Result with await Task.
+        /// </summary>
+        public static string ResultInAsyncAnalyzer_Title {
+            get {
+                return ResourceManager.GetString("ResultInAsyncAnalyzer_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Await the asynchronous call.
+        /// </summary>
+        public static string ResultInAsyncCodeFixProvider_Title {
+            get {
+                return ResourceManager.GetString("ResultInAsyncCodeFixProvider_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to String interpolation allows for better reading of the resulting string when compared to String.Format. You should use String.Format only when another method is supplying the format string..
         /// </summary>
         public static string StringFormatAnalyzer_Description {

--- a/src/Common/CodeCracker.Common/Properties/Resources.fr.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.fr.resx
@@ -214,4 +214,16 @@ Si l'erreur est attendu considérer ajouter du logging ou modifier le flow de co
   <data name="EmptyCatchBlockCodeFixProvider_RemoveAndDocumentation" xml:space="preserve">
     <value>Enlever le block Catch vide et ajouter un lien vers la documentation des bonnes pratiques de Try...Catch</value>
   </data>
+  <data name="ResultInAsyncAnalyzer_Title" xml:space="preserve">
+    <value>Replace Task.Result with await Task</value>
+  </data>
+  <data name="ResultInAsyncCodeFixProvider_Title" xml:space="preserve">
+    <value>Await the asynchronous call</value>
+  </data>
+  <data name="ResultInAsync_Description" xml:space="preserve">
+    <value>Calling Task.Result in an awaited method may lead to a deadlock. Obtain the result of the task with the await keyword to avoid deadlocks.</value>
+  </data>
+  <data name="ResultInAsync_MessageFormat" xml:space="preserve">
+    <value>await '{0}' rather than calling its Result.</value>
+  </data>
 </root>

--- a/src/Common/CodeCracker.Common/Properties/Resources.resx
+++ b/src/Common/CodeCracker.Common/Properties/Resources.resx
@@ -216,4 +216,16 @@
   <data name="EmptyCatchBlockCodeFixProvider_RemoveTry" xml:space="preserve">
     <value>Remove wrapping Try Block</value>
   </data>
+  <data name="ResultInAsyncAnalyzer_Title" xml:space="preserve">
+    <value>Replace Task.Result with await Task</value>
+  </data>
+  <data name="ResultInAsyncCodeFixProvider_Title" xml:space="preserve">
+    <value>Await the asynchronous call</value>
+  </data>
+  <data name="ResultInAsync_Description" xml:space="preserve">
+    <value>Calling Task.Result in an awaited method may lead to a deadlock. Obtain the result of the task with the await keyword to avoid deadlocks.</value>
+  </data>
+  <data name="ResultInAsync_MessageFormat" xml:space="preserve">
+    <value>await '{0}' rather than calling its Result.</value>
+  </data>
 </root>

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Design\InconsistentAccessibilityTests.MethodIndexerParameter.cs" />
     <Compile Include="Design\InconsistentAccessibilityTests.MethodIndexerReturnType.cs" />
     <Compile Include="Design\MakeMethodStaticTests.cs" />
+    <Compile Include="Design\ResultInAsyncTest.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensionsTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Performance\UseStaticRegexIsMatchTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Design/ResultInAsyncTest.cs
+++ b/test/CSharp/CodeCracker.Test/Design/ResultInAsyncTest.cs
@@ -1,0 +1,167 @@
+﻿using CodeCracker.CSharp.Design;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Design
+{
+    public class ResultInAsyncTest : CodeFixVerifier<ResultInAsyncAnalyzer, ResultInAsyncCodeFixProvider>
+    {
+        [Fact]
+        public async Task ResultInNonAsyncMethodIsOk()
+        {
+            const string test = @"
+                using System.Threading.Tasks;
+                public class MyClass
+                {
+                    public Task Execute()
+                    {
+                        return Asynchronous().Result;
+                    }
+                    public async Task Asynchronous()
+                    {
+                        return;
+                    }
+                }";
+            await VerifyCSharpHasNoDiagnosticsAsync(test);
+        }
+
+        [Fact]
+        public async Task WarningIfResultInAsync()
+        {
+            const string test = @"
+                using System.Threading.Tasks;
+                public class MyClass
+                {
+                    public async Task<int> Execute()
+                    {
+                        return Asynchronous().Result;
+                    }
+                    public async Task<int> Asynchronous()
+                    {
+                        return 5;
+                    }
+                }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.ResultInAsync.ToDiagnosticId(),
+                Message = string.Format(ResultInAsyncAnalyzer.MessageFormat.ToString(), "Asynchronous"),
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 32) }
+            };
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task FixResultInAsync()
+        {
+            const string source = @"
+                using System.Threading.Tasks;
+                public class MyClass
+                {
+                    public async Task<int> Execute()
+                    {
+                        return Asynchronous().Result;
+                    }
+                    public async Task<int> Asynchronous()
+                    {
+                        return 5;
+                    }
+                }";
+            const string fixtest = @"
+                using System.Threading.Tasks;
+                public class MyClass
+                {
+                    public async Task<int> Execute()
+                    {
+                        return await Asynchronous();
+                    }
+                    public async Task<int> Asynchronous()
+                    {
+                        return 5;
+                    }
+                }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task WarningIfNestedResultInAsync()
+        {
+            const string test = @"
+        namespace Nested.Namespaces
+        {
+            using System.Threading.Tasks;
+            public class ParentClass
+            {
+                public class MyClass
+                {
+                    public async Task Execute()
+                    {
+                        var x = ParentClass.MyClass.Asynchronous().Result.Length;
+                    }
+                    public static async Task<string> Asynchronous()
+                    {
+                        return ""Test"";
+                    }
+                }
+            }
+        }";
+
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.ResultInAsync.ToDiagnosticId(),
+                Message = string.Format(ResultInAsyncAnalyzer.MessageFormat.ToString(), "Asynchronous"),
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 53) }
+            };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task FixNestedResultInAsync()
+        {
+            const string source = @"
+        namespace Nested.Namespaces
+        {
+            using System.Threading.Tasks;
+            public class ParentClass
+            {
+                public class MyClass
+                {
+                    public async Task Execute()
+                    {
+                        var x = MyClass.Asynchronous().Result.Length;
+                    }
+                    public static async Task<string> Asynchronous()
+                    {
+                        return ""Test"";
+                    }
+                }
+            }
+        }";
+            const string fixtest = @"
+        namespace Nested.Namespaces
+        {
+            using System.Threading.Tasks;
+            public class ParentClass
+            {
+                public class MyClass
+                {
+                    public async Task Execute()
+                    {
+                        var x = (await MyClass.Asynchronous()).Length;
+                    }
+                    public static async Task<string> Asynchronous()
+                    {
+                        return ""Test"";
+                    }
+                }
+            }
+        }";
+
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #734 
Supersedes #805
**CC0122 Replace Task.Result with await Task**

Adds Design Warning CC0122 when `System.Threading.Tasks.Task<TResult>.Result` is used in `async` method.
The code fix provider replaces `.Result` with `async `

Screenshot of a non trivial case:
![cc0122](https://cloud.githubusercontent.com/assets/1673956/16567981/5c63f2aa-422d-11e6-9859-5a45f5b5cbb8.png)