### PR TITLE
Ignore member order on ReadonlyFieldAnalyzer

### DIFF
--- a/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
@@ -967,5 +967,29 @@ class TypeName
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
+
+        [Fact]
+        public async Task IgnoreWhenConstructorIsTheLastMember()
+        {
+            const string source = @"
+class Test
+{
+    private int value;
+    public int Value
+    {
+        get { return value; }
+        set { this.value = value; }
+    }
+    public void Foo()
+    {
+        value = 1;
+    }
+    public Test()
+    {
+        value = 8;
+    }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
     }
 }


### PR DESCRIPTION
Fix #812
Add constructor to the top of the list so we add fields with constructors initializers first