### PR TITLE
Ignore methods that implement interface in TaskNameAsync (CC0061)

### DIFF
--- a/src/CSharp/CodeCracker/Design/MakeMethodStaticAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/MakeMethodStaticAnalyzer.cs
@@ -52,16 +52,8 @@ namespace CodeCracker.CSharp.Design
 
             var semanticModel = context.SemanticModel;
             var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            var theClass = methodSymbol.ContainingType;
-            if (theClass.TypeKind == TypeKind.Interface) return;
-
-            var interfaceMembersWithSameName = theClass.AllInterfaces.SelectMany(i => i.GetMembers(methodSymbol.Name));
-            foreach (var memberSymbol in interfaceMembersWithSameName)
-            {
-                if (memberSymbol.Kind != SymbolKind.Method) continue;
-                var implementation = theClass.FindImplementationForInterfaceMember(memberSymbol);
-                if (implementation != null && implementation.Equals(methodSymbol)) return;
-            }
+            if (methodSymbol == null) return;
+            if (methodSymbol.IsImplementingInterface()) return;
 
             if (method.Body == null)
             {

--- a/src/CSharp/CodeCracker/Extensions/CSharpAnalyzerExtensions.cs
+++ b/src/CSharp/CodeCracker/Extensions/CSharpAnalyzerExtensions.cs
@@ -877,5 +877,38 @@ namespace CodeCracker
                 name = baseName + inscrementer++;
             return name;
         }
+
+        public static bool IsImplementingInterface(this MemberDeclarationSyntax member, SemanticModel semanticModel) =>
+            semanticModel.GetDeclaredSymbol(member).IsImplementingInterface();
+
+        public static bool IsImplementingInterface(this ISymbol memberSymbol)
+        {
+            if (memberSymbol == null) return false;
+            IMethodSymbol methodSymbol;
+            IEventSymbol eventSymbol;
+            IPropertySymbol propertySymbol;
+            if ((methodSymbol = memberSymbol as IMethodSymbol) != null)
+            {
+                if (methodSymbol.ExplicitInterfaceImplementations.Any()) return true;
+            }
+            else if ((propertySymbol = memberSymbol as IPropertySymbol) != null)
+            {
+                if (propertySymbol.ExplicitInterfaceImplementations.Any()) return true;
+            }
+            else if ((eventSymbol = memberSymbol as IEventSymbol) != null)
+            {
+                if (eventSymbol.ExplicitInterfaceImplementations.Any()) return true;
+            }
+            else return false;
+            var type = memberSymbol.ContainingType;
+            if (type == null) return false;
+            var interfaceMembersWithSameName = type.AllInterfaces.SelectMany(i => i.GetMembers(memberSymbol.Name));
+            foreach (var interfaceMember in interfaceMembersWithSameName)
+            {
+                var implementation = type.FindImplementationForInterfaceMember(interfaceMember);
+                if (implementation != null && implementation.Equals(memberSymbol)) return true;
+            }
+            return false;
+        }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
@@ -178,5 +178,59 @@ namespace CodeCracker.Test.CSharp.Style
     }";
             await VerifyCSharpFixAsync(source, fixtest);
         }
+
+        [Fact]
+        public async Task IgnoreMethodFromImplicitlyImplementedInterface()
+        {
+            const string source = @"
+using System.Threading.Tasks;
+public interface IBar
+{
+    Task Foo();
+}
+public class Bar : IBar
+{
+    public Task Foo()
+    {
+        throw new System.NotImplementedException();
+    }
+}";
+            //we still get the diagnostic for the interface itself
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.TaskNameAsync.ToDiagnosticId(),
+                Message = string.Format(TaskNameAsyncAnalyzer.MessageFormat, "FooAsync"),
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 10) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task IgnoreMethodFromExplicitlyImplementedInterface()
+        {
+            const string source = @"
+using System.Threading.Tasks;
+public interface IBar
+{
+    Task Foo();
+}
+public class Bar : IBar
+{
+    Task IBar.Foo()
+    {
+        throw new System.NotImplementedException();
+    }
+}";
+            //we still get the diagnostic for the interface itself
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.TaskNameAsync.ToDiagnosticId(),
+                Message = string.Format(TaskNameAsyncAnalyzer.MessageFormat, "FooAsync"),
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 10) }
+            };
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
     }
 }


### PR DESCRIPTION
Fix #793
Also, refactor the search for interface members on TaskNameAsyncAnalyzer and MakeMethodStaticAnalyzer.