### PR TITLE
Add support to remove unnecessary '.ToString()' in a string concatena…

### DIFF
--- a/src/CSharp/CodeCracker/CodeCracker.csproj
+++ b/src/CSharp/CodeCracker/CodeCracker.csproj
@@ -83,6 +83,8 @@
     <Compile Include="Style\ConsoleWriteLineCodeFixProvider.cs" />
     <Compile Include="Style\StringFormatFixAllProvider.cs" />
     <Compile Include="Style\SwitchToAutoPropCodeFixAllProvider.cs" />
+    <Compile Include="Style\UnnecessaryToStringInStringConcatenationAnalyzer.cs" />
+    <Compile Include="Style\UnnecessaryToStringInStringConcatenationCodeFixProvider.cs" />
     <Compile Include="Style\UseEmptyStringAnalyzer.cs" />
     <Compile Include="Style\UseEmptyStringCodeFixProvider.cs" />
     <Compile Include="Style\UseEmptyStringCodeFixProviderAll.cs" />

--- a/src/CSharp/CodeCracker/Style/UnnecessaryToStringInStringConcatenationAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/UnnecessaryToStringInStringConcatenationAnalyzer.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace CodeCracker.CSharp.Style
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UnnecessaryToStringInStringConcatenationAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string Title = "Unnecessary '.ToString()' call in string concatenation.";
+        internal const string MessageFormat = Title;
+        internal const string Category = SupportedCategories.Style;
+        const string Description = "The runtime automatically calls '.ToString()' method for" +
+            " string concatenation operations when there is no parameters. Remove them.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId.UnnecessaryToStringInStringConcatenation.ToDiagnosticId(),
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Info,
+            customTags: WellKnownDiagnosticTags.Unnecessary,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLinkUri: HelpLink.ForDiagnostic(DiagnosticId.UnnecessaryToStringInStringConcatenation));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) =>
+            context.RegisterSyntaxNodeAction(Analyzer, SyntaxKind.AddExpression);
+
+        private static void Analyzer(SyntaxNodeAnalysisContext context)
+        {
+            if (context.IsGenerated()) return;
+            var addExpression = context.Node as BinaryExpressionSyntax;
+
+            if (!addExpression.IsKind(SyntaxKind.AddExpression)) return;
+
+            var hasPlusToken = addExpression.ChildNodesAndTokens().Any(x => x.IsKind(SyntaxKind.PlusToken));
+            var hasInvocationExpression = addExpression.ChildNodesAndTokens().Any(x => x.IsKind(SyntaxKind.InvocationExpression));
+
+            //string concatenation must have PlusToken and an InvocationExpression
+            if (!hasPlusToken || !hasInvocationExpression) return;
+            var invocationExpressionsThatHaveToStringCall = GetInvocationExpressionsThatHaveToStringCall(addExpression);
+
+            foreach (var expression in invocationExpressionsThatHaveToStringCall)
+            { 
+                var lastDot = expression.Expression.ChildNodesAndTokens().Last(x => x.IsKind(SyntaxKind.DotToken));
+                var argumentList = expression.ChildNodes().Last(x => x.IsKind(SyntaxKind.ArgumentList));
+
+                //Only default call to ToString method must be accepted
+                if (expression.ArgumentList.Arguments.Count > 0)
+                    break;
+
+                var tree = expression.SyntaxTree;
+                var textspan = new TextSpan(lastDot.Span.Start, argumentList.Span.End - lastDot.Span.Start);
+
+                var diagnostic = Diagnostic.Create(Rule, Location.Create(context.Node.SyntaxTree, textspan));
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static System.Collections.Generic.List<InvocationExpressionSyntax> GetInvocationExpressionsThatHaveToStringCall(BinaryExpressionSyntax addExpression)
+        {
+            return addExpression.ChildNodes().OfType<InvocationExpressionSyntax>()
+                .Where(x => x.Expression.ToString().EndsWith(@".ToString"))
+                .ToList();
+        }
+    }
+}

--- a/src/CSharp/CodeCracker/Style/UnnecessaryToStringInStringConcatenationCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Style/UnnecessaryToStringInStringConcatenationCodeFixProvider.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodeCracker.CSharp.Style
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UnnecessaryParenthesisCodeFixProvider)), Shared]
+    public class UnnecessaryToStringInStringConcatenationCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticId.UnnecessaryToStringInStringConcatenation.ToDiagnosticId());
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            context.RegisterCodeFix(CodeAction.Create("Remove unnecessary ToString", ct => RemoveUnnecessaryToStringAsync(context.Document, diagnostic, ct), nameof(UnnecessaryToStringInStringConcatenationCodeFixProvider)), diagnostic);
+            return Task.FromResult(0);
+        }
+        private static async Task<Document> RemoveUnnecessaryToStringAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var invocationExpression =
+                root
+                .FindToken(diagnostic.Location.SourceSpan.Start)
+                .Parent
+                .AncestorsAndSelf()
+                .OfType<InvocationExpressionSyntax>()
+                .First();
+
+            var onlyMemberAccessNode =
+                invocationExpression
+                .ChildNodes()
+                .First()
+                .ChildNodes()
+                .First();
+
+            var newRoot = root.ReplaceNode(invocationExpression, onlyMemberAccessNode);
+
+            var newDocument = document.WithSyntaxRoot(newRoot);
+            return newDocument;
+        }
+
+    }
+
+}

--- a/src/Common/CodeCracker.Common/DiagnosticId.cs
+++ b/src/Common/CodeCracker.Common/DiagnosticId.cs
@@ -80,5 +80,6 @@
         NameOf_External = 108,
         StringFormatArgs_ExtraArgs = 111,
         AlwaysUseVarOnPrimitives = 105,
+        UnnecessaryToStringInStringConcatenation = 118,
     }
 }

--- a/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
+++ b/test/CSharp/CodeCracker.Test/CodeCracker.Test.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Refactoring\AllowMembersOrderingCodeFixProviderTests.StyleCop.cs" />
     <Compile Include="Reliability\UseConfigureAwaitFalseTests.cs" />
     <Compile Include="Style\ConsoleWriteLineTests.cs" />
+    <Compile Include="Style\UnnecessaryToStringInStringConcatenationTests.cs" />
     <Compile Include="Style\UseEmptyStringTest.cs" />
     <Compile Include="Style\UseStringEmptyTests.cs" />
     <Compile Include="Style\PropertyPrivateSetTests.cs" />

--- a/test/CSharp/CodeCracker.Test/Style/UnnecessaryToStringInStringConcatenationTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/UnnecessaryToStringInStringConcatenationTests.cs
@@ -1,0 +1,208 @@
+﻿using CodeCracker.CSharp.Style;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeCracker.Test.CSharp.Style
+{
+    public class UnnecessaryToStringInStringConcatenationTests : CodeFixVerifier<UnnecessaryToStringInStringConcatenationAnalyzer, UnnecessaryToStringInStringConcatenationCodeFixProvider>
+    {
+        [Fact]
+        public async Task InstantiatingAnObjectAndCallToStringInsideAStringConcatenationShouldGenerateDiagnosticResult()
+        {
+            const string source = @"var foo = ""a"" + new object().ToString();";
+
+            var expected = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(1, 29);
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task InstantiatingAnStringBuilderAndCallToStringInsideAStringConcatenationShouldGenerateDiagnosticResult()
+        {
+            const string source = @"var foo = ""a"" + new System.Text.StringBuilder().ToString();";
+
+            var expected = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(1, 48);
+
+            await VerifyCSharpDiagnosticAsync(source, expected);
+        }
+
+        [Fact]
+        public async Task CallToStringForAnInstantiatedObjectInsideAStringConcatenationShouldGenerateDiagnosticResult()
+        {
+            const string test = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class AuxClass
+        {
+            public override void ToString()
+            {
+                return ""Test""; 
+            }
+        }
+
+        class TypeName
+        {
+            public void Foo()
+            {
+                var auxClass = new AuxClass();
+
+                var bar = ""a"" + new AuxClass().ToString();
+                var foo = ""a"" + auxClass.ToString();
+                var far = ""a"" + new AuxClass().ToString() + auxClass.ToString() + new object().ToString(""C"");
+            }
+        }
+    }";
+
+            var expected1 = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(20, 47);
+            var expected2 = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(21, 41);
+            var expected3 = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(22, 47);
+            var expected4 = CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(22, 69);
+
+            var expected = new DiagnosticResult[] { expected1, expected2, expected3, expected4 };
+
+            await VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task CallToStringInsideAStringConcatenationWithAFormatParameterShouldNotGenerateDiagnosticResult()
+        {
+            const string source = @"var salary = ""salary: "" + 1000.ToString(""C"");";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+
+        [Fact]
+        public async Task CallToStringOutsideAStringConcatenationWithoutParameterShouldNotGenerateDiagnosticResult()
+        {
+            const string source = @"var value = 1000.ToString();";
+
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+
+        private static DiagnosticResult CreateUnnecessaryToStringInStringConcatenationDiagnosticResult(int expectedRow, int expectedColumn)
+        {
+            var expected = new DiagnosticResult
+            {
+                Id = DiagnosticId.UnnecessaryToStringInStringConcatenation.ToDiagnosticId(),
+                Message = "Unnecessary '.ToString()' call in string concatenation.",
+                Severity = DiagnosticSeverity.Info,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", expectedRow, expectedColumn) }
+            };
+
+            return expected;
+        }
+
+        [Fact]
+        public async Task FixReplacesToStringCallInAStringConcatenationWithAVariable()
+        {
+            const string test = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var text = ""def"";
+                var a = ""abc"" + text.ToString();
+                Console.Log(a);
+            }
+        }
+    }";
+
+            const string expected = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var text = ""def"";
+                var a = ""abc"" + text;
+                Console.Log(a);
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(test, expected);
+        }
+
+
+        [Fact]
+        public async Task FixReplacesToStringCallInAStringConcatenation()
+        {
+            const string test = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var a = ""abc"" + ""def"".ToString();
+                Console.Log(a);
+            }
+        }
+    }";
+
+            const string expected = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var a = ""abc"" + ""def"";
+                Console.Log(a);
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(test, expected);
+        }
+
+        [Fact]
+        public async Task FixReplacesToStringCallInAStringConcatenationWithAnObject()
+        {
+            const string test = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var foo = ""a"" + new object().ToString();
+                Console.Log(foo);
+            }
+        }
+    }";
+
+            const string expected = @"
+    using System;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            public async Task Foo()
+            {
+                var foo = ""a"" + new object();
+                Console.Log(foo);
+            }
+        }
+    }";
+            await VerifyCSharpFixAsync(test, expected);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #753 
Supersedes #824 

**Remove Unnecessary ToString in String Concatenation #753**

The code fix provider remove `.ToString()` in string concatenations.