### PR TITLE
Fixes #798

### DIFF
--- a/src/VisualBasic/CodeCracker/Style/TernaryOperatorCodeFixProviders.vb
+++ b/src/VisualBasic/CodeCracker/Style/TernaryOperatorCodeFixProviders.vb
@@ -112,7 +112,7 @@ Namespace Style
                 EnsureNothingAsType(semanticModel, type, typeSyntax).
                 ConvertToBaseType(elseType, type)
 
-            If ifAssign.OperatorToken.Text <> "=" Then
+            If ifAssign.OperatorToken.Text <> "=" AndAlso ifAssign.OperatorToken.Text = elseAssign.OperatorToken.Text Then
                 trueExpression = ifAssign.Right.
                 EnsureNothingAsType(semanticModel, type, typeSyntax).
                 ConvertToBaseType(ifType, type)
@@ -136,7 +136,11 @@ Namespace Style
                                                                      trueExpression.WithoutTrailingTrivia(),
                                                                      falseExpression.WithoutTrailingTrivia())
 
-            Dim assignment = SyntaxFactory.SimpleAssignmentStatement(ifAssign.Left.WithLeadingTrivia(leadingTrivia), ifAssign.OperatorToken, ternary).
+            Dim ternaryOperatorToken As SyntaxToken = If((ifAssign.OperatorToken.Text <> "=" OrElse elseAssign.OperatorToken.Text <> "=") AndAlso ifAssign.OperatorToken.Text <> elseAssign.OperatorToken.Text,
+                                                          SyntaxFactory.Token(SyntaxKind.EqualsToken),
+                                                          ifAssign.OperatorToken)
+
+            Dim assignment = SyntaxFactory.SimpleAssignmentStatement(ifAssign.Left.WithLeadingTrivia(leadingTrivia), ternaryOperatorToken, ternary).
                 WithTrailingTrivia(trailingTrivia).
                 WithAdditionalAnnotations(Formatter.Annotation)
 

--- a/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
+++ b/test/VisualBasic/CodeCracker.Test/Style/TernaryOperatorTests.vb
@@ -439,6 +439,84 @@ End Class"
         End Function
 
         <Fact>
+        Public Async Function WhenUsingConcatenationAssignmentOnIfAssignExpandsToConcatenateAtEndOfTernary() As Task
+            Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = ""test""
+        If True Then
+            x &= ""1""
+        Else
+            x = ""2""
+        End If
+    End Sub
+End Class"
+
+            Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = ""test""
+        x = If(True, x & ""1"", ""2"")
+    End Sub
+End Class"
+
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
+
+        <Fact>
+        Public Async Function WhenUsingAddAssiginmentOnIfAssignExpandsOperationProperly() As Task
+            Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        If True Then
+            x += 1
+        Else
+            x = 1
+        End If
+    End Sub
+End Class"
+
+            Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        x = If(True, x + 1, 1)
+    End Sub
+End Class"
+
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
+
+        <Fact>
+        Public Async Function WhenUsingSubtractAssiginmentOnIfAssignExpandsOperationProperly() As Task
+            Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        If True Then
+            x -= 1
+        Else
+            x = 1
+        End If
+    End Sub
+End Class"
+
+            Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        x = If(True, x - 1, 1)
+    End Sub
+End Class"
+
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
+        End Function
+
+        <Fact>
         Public Async Function WhenUsingAssignmentOperatorReturnSameAssignment() As Task
             Const source = "
 Class MyType
@@ -465,6 +543,32 @@ Class MyType
 End Class"
 
             Await VerifyBasicFixAsync(source, fix, formatBeforeCompare:=True)
+        End Function
+
+        <Fact>
+        Public Async Function WhenUsingDifferentAssiginmentsExpandsOperationProperly() As Task
+            Const source = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        If True Then
+            x += 1
+        Else
+            x -= 1
+        End If
+    End Sub
+End Class"
+
+            Const fix = "
+Public Class MyType
+    Public Sub Foo()
+        Dim x = 0
+        x = If(True, x + 1, x - 1)
+    End Sub
+End Class"
+
+            ' Allowing new diagnostics because without it the test fails because the compiler says Integer? is not defined.
+            Await VerifyBasicFixAsync(source, fix, allowNewCompilerDiagnostics:=True)
         End Function
     End Class
 


### PR DESCRIPTION
Fixes #798

The original code was able to handle a combination of simple and non-simple assignment operators if the simple one was on the if and the complex one on the else. I have amended the code so that the opposite case can be handled as well. The changes should also work if there are two different non-simple assignment operators on if and else.

Tests have been added for all the described scenarios.

I've encountered an issue whilst applying the fix for which I don't have a clear answer. On line 140 I wasn't able to call SyntaxFactory.Token(SyntaxKind.SimpleAssignmentStatement) as it would throw a System.ArgumentOutOfRangeException, but it builds and passes the tests with an EqualsToken. I'm not sure why this is the case.

Please let me know if any further amendment is needed.

Thanks.