### PR TITLE
Fix MakeReadonly with lambdas when field has initializer

### DIFF
--- a/src/CSharp/CodeCracker/Usage/ReadonlyFieldAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/ReadonlyFieldAnalyzer.cs
@@ -118,25 +118,28 @@ namespace CodeCracker.CSharp.Usage
         {
             if (fieldSymbol == null) return;
             if (!CanBeMadeReadonly(fieldSymbol)) return;
-            if ((method.MethodKind == MethodKind.StaticConstructor && fieldSymbol.IsStatic)
-            || (method.MethodKind == MethodKind.Constructor && !fieldSymbol.IsStatic))
+            if (!HasAssignmentInLambda(node)
+            && ((method.MethodKind == MethodKind.StaticConstructor && fieldSymbol.IsStatic)
+            || (method.MethodKind == MethodKind.Constructor && !fieldSymbol.IsStatic)))
                 AddVariableThatWasSkippedBeforeBecauseItLackedAInitializer(variablesToMakeReadonly, fieldSymbol, node, syntaxRefSemanticModel);
             else
                 RemoveVariableThatHasAssignment(variablesToMakeReadonly, fieldSymbol);
         }
 
-        private static void AddVariableThatWasSkippedBeforeBecauseItLackedAInitializer(Dictionary<IFieldSymbol, VariableDeclaratorSyntax> variablesToMakeReadonly, IFieldSymbol fieldSymbol, SyntaxNode assignment, SemanticModel semanticModel)
+        private static bool HasAssignmentInLambda(SyntaxNode assignment)
         {
             var parent = assignment.Parent;
             while (parent != null)
             {
                 if (parent is AnonymousFunctionExpressionSyntax)
-                    return;
-                if (parent is ConstructorDeclarationSyntax)
-                    break;
+                    return true;
                 parent = parent.Parent;
             }
+            return false;
+        }
 
+        private static void AddVariableThatWasSkippedBeforeBecauseItLackedAInitializer(Dictionary<IFieldSymbol, VariableDeclaratorSyntax> variablesToMakeReadonly, IFieldSymbol fieldSymbol, SyntaxNode assignment, SemanticModel semanticModel)
+        {
             if (!fieldSymbol.IsReadOnly && !variablesToMakeReadonly.Keys.Contains(fieldSymbol))
             {
                 var containingType = assignment.FirstAncestorOfKind(SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration);

--- a/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
@@ -850,6 +850,29 @@ class TypeName
         }
 
         [Fact]
+        public async Task FieldsAssignedOnLambdaWithInitializerDoesNotCreateDiagnostic()
+        {
+            const string source = @"
+using System;
+class C
+{
+    private readonly Action set;
+    private int i = 0;
+
+    public C()
+    {
+        set = () => i = 1;
+    }
+
+    public void Modify()
+    {
+        set();
+    }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(source);
+        }
+
+        [Fact]
         public async Task VariableInitializerDoesNotCreateDiagnostic()
         {
             const string source = @"


### PR DESCRIPTION
Fixes #853
Related to #544 but in that issue the variable was not initialized.