### PR TITLE
Fixed grammar in AbstractClassShouldNotHavePublicCtorsAnalyzer #839

### DIFF
--- a/src/CSharp/CodeCracker/Usage/AbstractClassShouldNotHavePublicCtorsAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Usage/AbstractClassShouldNotHavePublicCtorsAnalyzer.cs
@@ -10,7 +10,7 @@ namespace CodeCracker.CSharp.Usage
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class AbstractClassShouldNotHavePublicCtorsAnalyzer : DiagnosticAnalyzer
     {
-        internal const string Title = "Abastract class should not have public constructors.";
+        internal const string Title = "Abstract class should not have public constructors.";
         internal const string MessageFormat = "Constructor should not be public.";
         internal const string Category = SupportedCategories.Usage;
 


### PR DESCRIPTION
Fixes #839
Update grammar in AbstractClassShouldNotHavePublicCtorsAnalyzer.cs #839
