### PR TITLE
CC0031 Bug 926 check for null misses constructor

### DIFF
--- a/src/CSharp/CodeCracker/Design/UseInvokeMethodToFireEventAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Design/UseInvokeMethodToFireEventAnalyzer.cs
@@ -62,7 +62,7 @@ namespace CodeCracker.CSharp.Design
 
         private static bool HasCheckForNullThatReturns(InvocationExpressionSyntax invocation, SemanticModel semanticModel, ISymbol symbol)
         {
-            var method = invocation.FirstAncestorOfKind(SyntaxKind.MethodDeclaration) as MethodDeclarationSyntax;
+            var method = invocation.FirstAncestorOfKind(SyntaxKind.MethodDeclaration, SyntaxKind.ConstructorDeclaration) as BaseMethodDeclarationSyntax;
             if (method != null && method.Body != null)
             {
                 var ifs = method.Body.Statements.OfKind(SyntaxKind.IfStatement);

--- a/test/CSharp/CodeCracker.Test/Design/UseInvokeMethodToFireEventTests.cs
+++ b/test/CSharp/CodeCracker.Test/Design/UseInvokeMethodToFireEventTests.cs
@@ -1137,5 +1137,22 @@ public class Foo
 }";
             await VerifyCSharpHasNoDiagnosticsAsync(test.WrapInCSharpClass());
         }
+
+        [Fact]
+        public async void IgnoreIfInConstructorAndThatCheckedForNotNull()
+        {
+            //https://github.com/code-cracker/code-cracker/issues/926
+            const string test = @"
+public class Foo
+{
+    public Foo(System.Action action)
+    {
+        if (action == null)
+            throw new System.ArgumentNullException();
+        action();
+    }
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(test.WrapInCSharpClass());
+        }
     }
 }


### PR DESCRIPTION
Fixes #926.

Replaces PR #941.

Sorry for the confusion with the this PR.