### PR TITLE
Adding an "Async" method suffix should remove any embedded "Async" string

### DIFF
--- a/src/CSharp/CodeCracker/Performance/RemoveWhereWhenItIsPossibleAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Performance/RemoveWhereWhenItIsPossibleAnalyzer.cs
@@ -25,15 +25,7 @@ namespace CodeCracker.CSharp.Performance
             "Any",
             "Single",
             "SingleOrDefault",
-            "Count",
-            "FirstAsync",
-            "FirstOrDefaultAsync",
-            "LastAsync",
-            "LastOrDefaultAsync",
-            "AnyAsync",
-            "SingleAsync",
-            "SingleOrDefaultAsync",
-            "CountAsync"
+            "Count"
         };
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(

--- a/src/CSharp/CodeCracker/Performance/RemoveWhereWhenItIsPossibleAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Performance/RemoveWhereWhenItIsPossibleAnalyzer.cs
@@ -25,8 +25,17 @@ namespace CodeCracker.CSharp.Performance
             "Any",
             "Single",
             "SingleOrDefault",
-            "Count"
+            "Count",
+            "FirstAsync",
+            "FirstOrDefaultAsync",
+            "LastAsync",
+            "LastOrDefaultAsync",
+            "AnyAsync",
+            "SingleAsync",
+            "SingleOrDefaultAsync",
+            "CountAsync"
         };
+
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId.RemoveWhereWhenItIsPossible.ToDiagnosticId(),
             Title,

--- a/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
@@ -262,5 +262,137 @@ public class Bar : IBar
             };
             await VerifyCSharpDiagnosticAsync(source, expected);
         }
+
+        [Fact]
+        public async Task ChangeTaskNameWithAsyncNotAtTheEndWithUpperCaseLetter()
+        {
+            const string source = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await Test();
+            }
+
+            public Task<bool> TestAsyncFoo()
+            {
+                return true;
+            }
+        }
+
+    }";
+            const string fixtest = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await TestAsync();
+            }
+
+            public Task<bool> TestFooAsync()
+            {
+                return true;
+            }
+        }
+
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task ChangeTaskNameWithAsyncNotAtTheEndWithUnderline()
+        {
+            const string source = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await Test();
+            }
+
+            public Task<bool> TestAsync_Foo()
+            {
+                return true;
+            }
+        }
+
+    }";
+            const string fixtest = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await TestAsync();
+            }
+
+            public Task<bool> Test_FooAsync()
+            {
+                return true;
+            }
+        }
+
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+        [Fact]
+        public async Task ChangeTaskNameWithAsyncNotAtTheEndWithDigit()
+        {
+            const string source = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await Test();
+            }
+
+            public Task<bool> TestAsync0Foo()
+            {
+                return true;
+            }
+        }
+
+    }";
+            const string fixtest = @"
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            public methodTest()
+            {
+                await TestAsync();
+            }
+
+            public Task<bool> Test0FooAsync()
+            {
+                return true;
+            }
+        }
+
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
     }
 }

--- a/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/TaskNameASyncTests.cs
@@ -275,7 +275,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await Test();
+                await TestAsyncFoo();
             }
 
             public Task<bool> TestAsyncFoo()
@@ -294,7 +294,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await TestAsync();
+                await TestFooAsync();
             }
 
             public Task<bool> TestFooAsync()
@@ -319,7 +319,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await Test();
+                await TestAsync_Foo();
             }
 
             public Task<bool> TestAsync_Foo()
@@ -338,7 +338,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await TestAsync();
+                await Test_FooAsync();
             }
 
             public Task<bool> Test_FooAsync()
@@ -363,7 +363,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await Test();
+                await TestAsync0Foo();
             }
 
             public Task<bool> TestAsync0Foo()
@@ -382,7 +382,7 @@ public class Bar : IBar
         {
             public methodTest()
             {
-                await TestAsync();
+                await Test0FooAsync();
             }
 
             public Task<bool> Test0FooAsync()


### PR DESCRIPTION
Fixes #922