### PR TITLE
Fixes #930 CC0020 cannot be used when types are declared

### DIFF
--- a/src/CSharp/CodeCracker/Style/ConvertLambdaExpressionToMethodGroupAnalyzer.cs
+++ b/src/CSharp/CodeCracker/Style/ConvertLambdaExpressionToMethodGroupAnalyzer.cs
@@ -65,7 +65,13 @@ namespace CodeCracker.CSharp.Style
                 : (node as ParenthesizedLambdaExpressionSyntax)?.Body;
 
             var invocation = body as InvocationExpressionSyntax;
-            if (invocation != null) return invocation;
+
+            if (invocation != null)
+            {
+                if (invocation.Expression is GenericNameSyntax && (((GenericNameSyntax)invocation.Expression).TypeArgumentList.Arguments.Count > 0)) return null;
+
+                return invocation;
+            }
 
             var possibleBlock = body as BlockSyntax;
             if (possibleBlock == null || possibleBlock.Statements.Count != 1) return null;

--- a/test/CSharp/CodeCracker.Test/Style/ConvertLambdaExpressionToMethodGroupTests.cs
+++ b/test/CSharp/CodeCracker.Test/Style/ConvertLambdaExpressionToMethodGroupTests.cs
@@ -598,5 +598,23 @@ namespace ConsoleApplication4
 ";
             await VerifyCSharpHasNoDiagnosticsAsync(oldCode);
         }
+
+        [Fact]
+        public async Task DoNotCreateDiagnosticWhenSubstitutionMayBreakTypeConversion()
+        {
+            const string oldCode = @"
+using System.Linq;
+class Foo
+{
+    void M()
+    {
+        var xs = new System.Collections.Generic.List<int>();
+        xs.Select(x => Func<int>(x));
+    }
+    object Func<T>(object x) => x;
+}";
+            await VerifyCSharpHasNoDiagnosticsAsync(oldCode);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #930 by checking if the calling method has generic type definitions. There could be cases that the generic type can be inferred but I'm not checking for that.