### PR TITLE
Insert missing link to Issue #66 in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ and [#10](https://github.com/code-cracker/code-cracker/issues/10).
 
 These are the 4 severity levels supported on Roslyn and how they are understood on the Code Cracker project:
 
-1. **Hidden**: Only used for refactorings. See #66 (and its comments) to understand why.
+1. **Hidden**: Only used for refactorings. See [#66](https://github.com/code-cracker/code-cracker/issues/66) (and its comments) to understand why.
 2. **Info**: An alternative way (ex: replacing for with foreach). Clearly, a matter of opinion and/or current way could be correct, or maybe the new code could be correct. We cannot determine.
 3. **Warning**: Code that could/should be improved. It is a code smell and most likely is wrong, but there are situations where the pattern is acceptable or desired.
 4. **Error**: Clearly a mistake (ex: throwing ArgumentException with a non-existent parameter). There is no situation where this code could be correct. There are no differences of opinion.


### PR DESCRIPTION
This PR inserts a missing link in the readme to issue #66, like it is done for all other referenced issues in the readme.