### PR TITLE
#903 (#CC0052): Fix for Duplication of Directives When Fixing Readonly

### DIFF
--- a/src/CSharp/CodeCracker/Usage/ReadonlyFieldCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Usage/ReadonlyFieldCodeFixProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -60,8 +61,8 @@ namespace CodeCracker.CSharp.Usage
             var newFieldDeclaration = fieldDeclaration.WithDeclaration(newDeclaration);
             var newReadonlyFieldDeclaration = fieldDeclaration.WithDeclaration(SyntaxFactory.VariableDeclaration(fieldDeclaration.Declaration.Type, SyntaxFactory.SeparatedList(new[] { variableToMakeReadonly })))
                 .WithoutLeadingTrivia()
-                .WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia("\r\n"))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
+                .WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia(Environment.NewLine))
                 .WithAdditionalAnnotations(Formatter.Annotation);
             var newRoot = root.ReplaceNode(fieldDeclaration, new[] { newFieldDeclaration, newReadonlyFieldDeclaration });
             return newRoot;

--- a/src/CSharp/CodeCracker/Usage/ReadonlyFieldCodeFixProvider.cs
+++ b/src/CSharp/CodeCracker/Usage/ReadonlyFieldCodeFixProvider.cs
@@ -44,10 +44,13 @@ namespace CodeCracker.CSharp.Usage
 
         private static SyntaxNode MakeSingleFieldReadonly(SyntaxNode root, FieldDeclarationSyntax fieldDeclaration)
         {
-            var newFieldDeclaration = fieldDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
-                .WithTrailingTrivia(fieldDeclaration.GetTrailingTrivia())
-                .WithLeadingTrivia(fieldDeclaration.GetLeadingTrivia())
-                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var newFieldDeclaration = fieldDeclaration
+                                        .WithoutLeadingTrivia()
+                                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
+                                        .WithTrailingTrivia(fieldDeclaration.GetTrailingTrivia())
+                                        .WithLeadingTrivia(fieldDeclaration.GetLeadingTrivia())
+                                        .WithAdditionalAnnotations(Formatter.Annotation);
             var newRoot = root.ReplaceNode(fieldDeclaration, newFieldDeclaration);
             return newRoot;
         }
@@ -57,7 +60,7 @@ namespace CodeCracker.CSharp.Usage
             var newFieldDeclaration = fieldDeclaration.WithDeclaration(newDeclaration);
             var newReadonlyFieldDeclaration = fieldDeclaration.WithDeclaration(SyntaxFactory.VariableDeclaration(fieldDeclaration.Declaration.Type, SyntaxFactory.SeparatedList(new[] { variableToMakeReadonly })))
                 .WithoutLeadingTrivia()
-                .WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia("\n"))
+                .WithTrailingTrivia(SyntaxFactory.ParseTrailingTrivia("\r\n"))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
                 .WithAdditionalAnnotations(Formatter.Annotation);
             var newRoot = root.ReplaceNode(fieldDeclaration, new[] { newFieldDeclaration, newReadonlyFieldDeclaration });

--- a/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
@@ -433,6 +433,77 @@ class TypeName
             await VerifyCSharpFixAsync(source, fixtest);
         }
 
+
+        [Fact]
+        public async Task DoesNotDuplicateLeadingDirectivesOnFixSingle()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+	    public class Foo
+	    {
+		    #region standard
+		    Foo foo1 = new Foo();
+		    #endregion
+
+            #region withAccessModifier
+            private Foo foo2 = new Foo();
+            #endregion
+
+            #region withStatic
+            private static Foo foo3 = new Foo();
+            #endregion
+	    }
+    }";
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+	    public class Foo
+	    {
+		    #region standard
+		    readonly Foo foo1 = new Foo();
+		    #endregion
+
+            #region withAccessModifier
+            private readonly Foo foo2 = new Foo();
+            #endregion
+
+            #region withStatic
+            private static readonly Foo foo3 = new Foo();
+            #endregion
+	    }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
+
+        [Fact]
+        public async Task DoesNotDuplicateLeadingDirectivesOnFixAll()
+        {
+            const string source = @"
+    namespace ConsoleApplication1
+    {
+	    public class Foo
+	    {
+		    #region standard
+		    Foo foo1, foo2 = new Foo(), foo3;
+            #endregion
+	    }
+    }";
+            const string fixtest = @"
+    namespace ConsoleApplication1
+    {
+        public class Foo
+        {
+            #region standard
+            Foo foo1, foo3;
+            readonly Foo foo2 = new Foo();
+            #endregion
+        }
+    }";
+            await VerifyCSharpFixAsync(source, fixtest);
+        }
+
         [Fact]
         public async Task FieldsWithAssignmentOnDeclarationWithSingleDeclarationCreatesDiagnostic()
         {

--- a/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
+++ b/test/CSharp/CodeCracker.Test/Usage/ReadonlyFieldTests.cs
@@ -483,12 +483,12 @@ class TypeName
             const string source = @"
     namespace ConsoleApplication1
     {
-	    public class Foo
-	    {
-		    #region standard
-		    Foo foo1, foo2 = new Foo(), foo3;
+        public class Foo
+        {
+            #region standard
+            Foo foo1, foo2 = new Foo(), foo3;
             #endregion
-	    }
+        }
     }";
             const string fixtest = @"
     namespace ConsoleApplication1
@@ -502,7 +502,7 @@ class TypeName
         }
     }";
             await VerifyCSharpFixAsync(source, fixtest);
-        }
+        }    
 
         [Fact]
         public async Task FieldsWithAssignmentOnDeclarationWithSingleDeclarationCreatesDiagnostic()


### PR DESCRIPTION
Fixes # 903.
This PR is fixed the duplication of regions created when the CC0052 diagnostic fix is applied to one or more variable declarations.
